### PR TITLE
[FEATURE] Allow to specify type and override even simple types

### DIFF
--- a/Classes/Flowpack/ElasticSearch/Annotations/Mapping.php
+++ b/Classes/Flowpack/ElasticSearch/Annotations/Mapping.php
@@ -75,6 +75,15 @@ final class Mapping {
 	public $analyzer;
 
 	/**
+	 * The type to use for this
+	 * Defaults to the property/field type.
+	 *
+	 * @var string
+	 * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/mapping-types.html
+	 */
+	public $type;
+
+	/**
 	 * The date format.
 	 * Defaults to `dateOptionalTime`.
 	 *

--- a/Classes/Flowpack/ElasticSearch/Mapping/EntityMappingBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/Mapping/EntityMappingBuilder.php
@@ -83,10 +83,10 @@ class EntityMappingBuilder {
 	 */
 	protected function augmentMappingByProperty(\Flowpack\ElasticSearch\Domain\Model\Mapping $mapping, $className, $propertyName) {
 		list($propertyType) = $this->reflectionService->getPropertyTagValues($className, $propertyName, 'var');
-		if (\TYPO3\Flow\Utility\TypeHandling::isSimpleType($propertyType)) {
-			$mappingType = $propertyType;
-		} elseif (($transformAnnotation = $this->reflectionService->getPropertyAnnotation($className, $propertyName, 'Flowpack\ElasticSearch\Annotations\Transform')) !== NULL) {
+		if (($transformAnnotation = $this->reflectionService->getPropertyAnnotation($className, $propertyName, 'Flowpack\ElasticSearch\Annotations\Transform')) !== NULL) {
 			$mappingType = $this->transformerFactory->create($transformAnnotation->type)->getTargetMappingType();
+		} elseif (\TYPO3\Flow\Utility\TypeHandling::isSimpleType($propertyType)) {
+			$mappingType = $propertyType;
 		} elseif ($propertyType === '\DateTime') {
 			$mappingType = 'date';
 		} else {


### PR DESCRIPTION
This adds the type attribute to the Mapping annotation to allow
overriding of the detected type.

The EntityMappingBuilder is changed so it will use a Mapping annotation
even on properties of a simple type, before such an annotation would
silently be ignored.
