### PR TITLE
[BUGFIX] Building and showing mapping information breaks

### DIFF
--- a/Classes/Flowpack/ElasticSearch/Command/MappingCommandController.php
+++ b/Classes/Flowpack/ElasticSearch/Command/MappingCommandController.php
@@ -145,9 +145,21 @@ class MappingCommandController extends \TYPO3\Flow\Cli\CommandController {
 		$markup = '';
 		if ($entityValue === NULL || $backendValue === NULL || $entityValue === $backendValue) {
 			$markup .= "\x1b[" . ($entityValue ? '31' : '30') . ';' . ($backendValue ? '42' : '0') . 'm';
+			if (is_array($entityValue)) {
+				$entityValue = var_export($entityValue, TRUE);
+			}
+			if (is_array($backendValue)) {
+				$backendValue = var_export($backendValue, TRUE);
+			}
 			$markup .= $entityValue ? : $backendValue;
 			$markup .= "\x1b[0m";
 		} else {
+			if (is_array($entityValue)) {
+				$entityValue = var_export($entityValue, TRUE);
+			}
+			if (is_array($backendValue)) {
+				$backendValue = var_export($backendValue, TRUE);
+			}
 			$markup .= "\x1b[31m" . $entityValue . "\x1b[0m";
 			$markup .= "\x1b[30;42m" . $backendValue . "\x1b[0m";
 		}

--- a/Classes/Flowpack/ElasticSearch/Indexer/Object/IndexInformer.php
+++ b/Classes/Flowpack/ElasticSearch/Indexer/Object/IndexInformer.php
@@ -44,6 +44,7 @@ class IndexInformer {
 	public function getClassesAndAnnotations() {
 		static $classesAndAnnotations;
 		if ($classesAndAnnotations === NULL) {
+			$classesAndAnnotations = array();
 			foreach (array_keys($this->indexAnnotations) AS $className) {
 				$classesAndAnnotations[$className] = $this->indexAnnotations[$className]['annotation'];
 			}


### PR DESCRIPTION
If no Indexable annotations are used, the use of a NULL value in a
foreach loop would break the code.

Also the mapping:showstatus would break on "complex" mapping settings
that are not simple strings.
