### PR TITLE
[!!!][TASK] Change transformer interface to use non static methods

### DIFF
--- a/Classes/Flowpack/ElasticSearch/Indexer/Object/Transform/CollectionStringCastTransformer.php
+++ b/Classes/Flowpack/ElasticSearch/Indexer/Object/Transform/CollectionStringCastTransformer.php
@@ -24,14 +24,14 @@ class CollectionStringCastTransformer implements TransformerInterface {
 	 * @static
 	 * @return string
 	 */
-	public static function getTargetMappingType() {
-		return 'array';
+	public function getTargetMappingType() {
+		return 'string';
 	}
 
 	/**
 	 * @static
 	 */
-	public static function transformByAnnotation($source, \Flowpack\ElasticSearch\Annotations\Transform $annotation) {
+	public function transformByAnnotation($source, \Flowpack\ElasticSearch\Annotations\Transform $annotation) {
 		$array = array();
 		foreach ($source as $item) {
 			$array[] = (string)$item;

--- a/Classes/Flowpack/ElasticSearch/Indexer/Object/Transform/DateTransformer.php
+++ b/Classes/Flowpack/ElasticSearch/Indexer/Object/Transform/DateTransformer.php
@@ -24,7 +24,7 @@ class DateTransformer implements TransformerInterface {
 	 * @static
 	 * @return string
 	 */
-	public static function getTargetMappingType() {
+	public function getTargetMappingType() {
 		return 'date';
 	}
 
@@ -34,8 +34,8 @@ class DateTransformer implements TransformerInterface {
 	 *
 	 * @return string
 	 */
-	public static function transformByAnnotation($source, \Flowpack\ElasticSearch\Annotations\Transform $annotation) {
-		return $source->format($annotation->options['format']);
+	public function transformByAnnotation($source, \Flowpack\ElasticSearch\Annotations\Transform $annotation) {
+		return $source->format($annotation->options['format'] ?: 'Y-m-d');
 	}
 }
 

--- a/Classes/Flowpack/ElasticSearch/Indexer/Object/Transform/StringCastTransformer.php
+++ b/Classes/Flowpack/ElasticSearch/Indexer/Object/Transform/StringCastTransformer.php
@@ -24,14 +24,14 @@ class StringCastTransformer implements TransformerInterface {
 	 * @static
 	 * @return string
 	 */
-	public static function getTargetMappingType() {
+	public function getTargetMappingType() {
 		return 'string';
 	}
 
 	/**
 	 * @static
 	 */
-	public static function transformByAnnotation($source, \Flowpack\ElasticSearch\Annotations\Transform $annotation) {
+	public function transformByAnnotation($source, \Flowpack\ElasticSearch\Annotations\Transform $annotation) {
 		return (string)$source;
 	}
 }

--- a/Classes/Flowpack/ElasticSearch/Indexer/Object/Transform/TransformerInterface.php
+++ b/Classes/Flowpack/ElasticSearch/Indexer/Object/Transform/TransformerInterface.php
@@ -24,11 +24,11 @@ interface TransformerInterface {
 	 * @abstract
 	 * @return string
 	 */
-	public static function getTargetMappingType();
+	public function getTargetMappingType();
 
 	/**
 	 * @static
 	 */
-	public static function transformByAnnotation($source, \Flowpack\ElasticSearch\Annotations\Transform $annotation);
+	public function transformByAnnotation($source, \Flowpack\ElasticSearch\Annotations\Transform $annotation);
 }
 


### PR DESCRIPTION
Currently the getTargetMappingType and transformByAnnotation are static
method. This patch change this to allow more complex transformer that need
DI.

This change is breaking if you use custom transform class. In this case
you just need to adapt the previously static methods.
