### PR TITLE
[TASK] Skip index not used by the current application in Mapping Command

### DIFF
--- a/Classes/Flowpack/ElasticSearch/Indexer/Object/IndexInformer.php
+++ b/Classes/Flowpack/ElasticSearch/Indexer/Object/IndexInformer.php
@@ -11,6 +11,7 @@ namespace Flowpack\ElasticSearch\Indexer\Object;
  * The TYPO3 project - inspiring people to share!                         *
  *                                                                        */
 
+use Flowpack\ElasticSearch\Annotations\Indexable;
 use TYPO3\Flow\Annotations as Flow;
 
 /**
@@ -51,6 +52,21 @@ class IndexInformer {
 		}
 
 		return $classesAndAnnotations;
+	}
+
+	/**
+	 * Returns all indexes name deplared in class annotations
+	 *
+	 * @return array
+	 */
+	public function getAllIndexName() {
+		$indexes = array();
+		foreach ($this->getClassesAndAnnotations() as $configuration) {
+			/** @var Indexable $configuration */
+			$indexes[$configuration->indexName] = $configuration->indexName;
+		}
+
+		return array_keys($indexes);
 	}
 
 	/**

--- a/Classes/Flowpack/ElasticSearch/Mapping/BackendMappingBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/Mapping/BackendMappingBuilder.php
@@ -12,6 +12,7 @@ namespace Flowpack\ElasticSearch\Mapping;
  *                                                                        */
 
 use Flowpack\ElasticSearch\Domain\Model;
+use Flowpack\ElasticSearch\Indexer\Object\IndexInformer;
 use TYPO3\Flow\Annotations as Flow;
 
 /**
@@ -35,6 +36,12 @@ class BackendMappingBuilder {
 	protected $indicesWithoutTypeInformation = NULL;
 
 	/**
+	 * @Flow\Inject
+	 * @var IndexInformer
+	 */
+	protected $indexInformer;
+
+	/**
 	 * Builds a Mapping collection from the annotation sources that are present
 	 *
 	 * @throws \Flowpack\ElasticSearch\Exception
@@ -50,7 +57,12 @@ class BackendMappingBuilder {
 		$response = $this->client->request('GET', '/_mapping');
 		$mappingInformation = new MappingCollection(MappingCollection::TYPE_BACKEND);
 		$mappingInformation->setClient($this->client);
+		$indexNames = $this->indexInformer->getAllIndexName();
+
 		foreach ($response->getTreatedContent() AS $indexName => $indexSettings) {
+			if (!in_array($indexName, $indexNames)) {
+				continue;
+			}
 			$index = new Model\Index($indexName);
 			if (empty($indexSettings)) {
 				$this->indicesWithoutTypeInformation[] = $indexName;


### PR DESCRIPTION
By default the current Mapping CLI tools show all indexes configured in
ElasticSearch. When the ES server is used by other applications, the
command output is bloated by unneeded informations.

This patch add a method to the IndexInformer to skip ES indexes not
declared in the Flow application.
