### PR TITLE
[TASK] Add support for ES multi_fields

### DIFF
--- a/Classes/Flowpack/ElasticSearch/Annotations/Mapping.php
+++ b/Classes/Flowpack/ElasticSearch/Annotations/Mapping.php
@@ -93,10 +93,24 @@ final class Mapping {
 	public $format;
 
 	/**
+	 * @var array
+	 * @see http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/_multi_fields.html
+	 */
+	public $fields;
+
+	/**
 	 * Returns this class's properties as type/value array in order to directly use it for mapping information
 	 */
 	public function getPropertiesArray() {
-		return get_object_vars($this);
+		$properties = get_object_vars($this);
+		unset($properties['fields']);
+		return $properties;
+	}
+
+	/**
+	 * @return array
+	 */
+	public function getFields() {
+		return $this->fields;
 	}
 }
-


### PR DESCRIPTION
Add a support for multi_fields mapping support. See the official documentation:
http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/_multi_fields.html

The configuration can be done with the normal Mapping annotation, like this::

```
@ElasticSearch\Mapping(index_name="name", analyzer="custom_french_analyzer", fields={@ElasticSearch\Mapping(index_name="nameHasTag", analyzer="tag_analyzer")})
```

The root mapping define the first field in the list, and all the mapping in the multi_fields attributes define the other mapping. No changes are needed for the indexing.
