### PR TITLE
[BUGFIX] Fix use of 'ok' in return values (ES 1.0 compatibility)

### DIFF
--- a/Classes/Flowpack/ElasticSearch/Command/IndexCommandController.php
+++ b/Classes/Flowpack/ElasticSearch/Command/IndexCommandController.php
@@ -51,7 +51,7 @@ class IndexCommandController extends \TYPO3\Flow\Cli\CommandController {
 	protected $objectIndexer;
 
 	/**
-	 * Creat a new index in ElasticSearch
+	 * Create a new index in ElasticSearch
 	 *
 	 * @param string $indexName The name of the new index
 	 * @param string $clientName The client name to use
@@ -195,7 +195,7 @@ class IndexCommandController extends \TYPO3\Flow\Cli\CommandController {
 							$this->objectIndexer->indexObject($this->persistenceManager->getObjectByIdentifier($identifier, $className));
 							$inserted++;
 						} catch (\Exception $exception) {
-							$result->forProperty($className)->addError(new Error('An error occured while trying to add an object to the ElasticSearch backend. The exception message was "%s".', 1340356330, array($exception->getMessage())));
+							$result->forProperty($className)->addError(new Error('An error occurred while trying to add an object to the ElasticSearch backend. The exception message was "%s".', 1340356330, array($exception->getMessage())));
 						}
 					}
 					foreach ($states[ObjectIndexer::ACTION_TYPE_UPDATE] AS $identifier) {
@@ -203,7 +203,7 @@ class IndexCommandController extends \TYPO3\Flow\Cli\CommandController {
 							$this->objectIndexer->indexObject($this->persistenceManager->getObjectByIdentifier($identifier, $className));
 							$updated++;
 						} catch (\Exception $exception) {
-							$result->forProperty($className)->addError(new Error('An error occured while trying to update an object to the ElasticSearch backend. The exception message was "%s".', 1340358590, array($exception->getMessage())));
+							$result->forProperty($className)->addError(new Error('An error occurred while trying to update an object to the ElasticSearch backend. The exception message was "%s".', 1340358590, array($exception->getMessage())));
 						}
 					}
 					$this->outputFormatted("Objects inserted: <b>%s</b>", array($inserted), 8);
@@ -216,7 +216,7 @@ class IndexCommandController extends \TYPO3\Flow\Cli\CommandController {
 
 		if ($result->hasErrors()) {
 			$this->outputLine();
-			$this->outputLine('The following errors occured:');
+			$this->outputLine('The following errors occurred:');
 			/** @var $error \TYPO3\Flow\Error\Error */
 			foreach ($result->getFlattenedErrors() as $className => $errors) {
 				foreach ($errors as $error) {

--- a/Classes/Flowpack/ElasticSearch/Command/MappingCommandController.php
+++ b/Classes/Flowpack/ElasticSearch/Command/MappingCommandController.php
@@ -115,8 +115,7 @@ class MappingCommandController extends \TYPO3\Flow\Cli\CommandController {
 				print_r($mapping->getProperties(), TRUE)
 			));
 			$response = $mapping->apply();
-			$treatedResponse = $response->getTreatedContent();
-			if ($response->getStatusCode() === 200 && isset($treatedResponse['ok']) && $treatedResponse['ok'] === TRUE) {
+			if ($response->getStatusCode() === 200) {
 				$this->outputFormatted('<b>OK</b>');
 			} else {
 				$this->outputFormatted('<b>NOT OK</b>, response code was %d, response body was: %s', array($response->getStatusCode(), $response->getOriginalResponse()->getContent()), 4);

--- a/Classes/Flowpack/ElasticSearch/Domain/Model/AbstractType.php
+++ b/Classes/Flowpack/ElasticSearch/Domain/Model/AbstractType.php
@@ -89,7 +89,7 @@ abstract class AbstractType {
 		$response = $this->request('DELETE', '/' . $id);
 		$treatedContent = $response->getTreatedContent();
 
-		return $response->getStatusCode() === 200 && $treatedContent['ok'] === TRUE && $treatedContent['found'] === TRUE;
+		return $response->getStatusCode() === 200 && $treatedContent['found'] === TRUE;
 	}
 
 	/**
@@ -107,11 +107,10 @@ abstract class AbstractType {
 
 	/**
 	 * @param array $searchQuery The search query TODO: make it an object
+	 * @return \Flowpack\ElasticSearch\Transfer\Response
 	 */
 	public function search(array $searchQuery) {
-		$response = $this->request('GET', '/_search', array(), json_encode($searchQuery));
-
-		return $response;
+		return $this->request('GET', '/_search', array(), json_encode($searchQuery));
 	}
 
 	/**

--- a/Classes/Flowpack/ElasticSearch/Domain/Model/Document.php
+++ b/Classes/Flowpack/ElasticSearch/Domain/Model/Document.php
@@ -103,10 +103,6 @@ class Document {
 		$response = $this->request($method, $path, array(), json_encode($this->data));
 		$treatedContent = $response->getTreatedContent();
 
-		if ($treatedContent['ok'] !== TRUE) {
-			throw new \Flowpack\ElasticSearch\Exception('An error occured while trying to store a document.', 1339149673);
-		}
-
 		$this->id = $treatedContent['_id'];
 		$this->version = $treatedContent['_version'];
 		$this->dirty = FALSE;

--- a/Classes/Flowpack/ElasticSearch/Domain/Model/TypeGroup.php
+++ b/Classes/Flowpack/ElasticSearch/Domain/Model/TypeGroup.php
@@ -25,7 +25,7 @@ class TypeGroup extends AbstractType {
 
 	/**
 	 * @param Index $index
-	 * @param string $name
+	 * @param array $types
 	 */
 	public function __construct(Index $index, array $types) {
 		parent::__construct($index);

--- a/Classes/Flowpack/ElasticSearch/Indexer/Object/ObjectIndexer.php
+++ b/Classes/Flowpack/ElasticSearch/Indexer/Object/ObjectIndexer.php
@@ -140,7 +140,7 @@ class ObjectIndexer {
 
 	/**
 	 * Returns if, and what, treatment an object requires regarding the index state,
-	 * i.e. it checks the given object agains the index and tells whether deletion, update or creation is required.
+	 * i.e. it checks the given object against the index and tells whether deletion, update or creation is required.
 	 *
 	 * @param $object
 	 * @param \Flowpack\ElasticSearch\Domain\Model\Client $client


### PR DESCRIPTION
Elasticsearch 1.0 does no longer return 'ok' as it does not add any
useful information. This it is no longer checked.

Along the way this change fixes some typos and CGL glitches.
