### PR TITLE
[TASK] Use realtimeIndexing.enabled from TYPO3CR.Search settings

### DIFF
--- a/Classes/Flowpack/ElasticSearch/Indexer/Aspect/IndexerAspect.php
+++ b/Classes/Flowpack/ElasticSearch/Indexer/Aspect/IndexerAspect.php
@@ -27,7 +27,7 @@ class IndexerAspect {
 	protected $objectIndexer;
 
 	/**
-	 * @Flow\AfterReturning("setting(Flowpack.ElasticSearch.realtimeIndexing.enabled) && within(TYPO3\Flow\Persistence\PersistenceManagerInterface) && method(public .+->(add|update)())")
+	 * @Flow\AfterReturning("setting(TYPO3.TYPO3CR.Search.realtimeIndexing.enabled) && within(TYPO3\Flow\Persistence\PersistenceManagerInterface) && method(public .+->(add|update)())")
 	 * @param \TYPO3\Flow\Aop\JoinPointInterface $joinPoint
 	 * @return string
 	 */
@@ -38,7 +38,7 @@ class IndexerAspect {
 	}
 
 	/**
-	 * @Flow\AfterReturning("setting(Flowpack.ElasticSearch.realtimeIndexing.enabled) && within(TYPO3\Flow\Persistence\PersistenceManagerInterface) && method(public .+->(remove)())")
+	 * @Flow\AfterReturning("setting(TYPO3.TYPO3CR.Search.realtimeIndexing.enabled) && within(TYPO3\Flow\Persistence\PersistenceManagerInterface) && method(public .+->(remove)())")
 	 * @param \TYPO3\Flow\Aop\JoinPointInterface $joinPoint
 	 * @return string
 	 */

--- a/Classes/Flowpack/ElasticSearch/Package.php
+++ b/Classes/Flowpack/ElasticSearch/Package.php
@@ -45,7 +45,7 @@ class Package extends BasePackage {
 	 */
 	public function prepareRealtimeIndexing(\TYPO3\Flow\Core\Bootstrap $bootstrap) {
 		$this->configurationManager = $bootstrap->getObjectManager()->get('TYPO3\Flow\Configuration\ConfigurationManager');
-		$settings = $this->configurationManager->getConfiguration(\TYPO3\Flow\Configuration\ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, $this->getPackageKey());
+		$settings = $this->configurationManager->getConfiguration(\TYPO3\Flow\Configuration\ConfigurationManager::CONFIGURATION_TYPE_SETTINGS, 'TYPO3.TYPO3CR.Search');
 		if (isset($settings['realtimeIndexing']['enabled']) && $settings['realtimeIndexing']['enabled'] === TRUE) {
 			$bootstrap->getSignalSlotDispatcher()->connect('Flowpack\ElasticSearch\Indexer\Object\Signal\SignalEmitter', 'objectUpdated', 'Flowpack\ElasticSearch\Indexer\Object\ObjectIndexer', 'indexObject');
 			$bootstrap->getSignalSlotDispatcher()->connect('Flowpack\ElasticSearch\Indexer\Object\Signal\SignalEmitter', 'objectPersisted', 'Flowpack\ElasticSearch\Indexer\Object\ObjectIndexer', 'indexObject');

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -5,11 +5,8 @@ Flowpack:
       default:
         - host: localhost
           port: 9200
-        - host: localhost
-          port: 9201
 
     realtimeIndexing:
-      enabled: TRUE
       client: default
     transfer:
       # The timeout in sections for connections between Flow and Elastic Search:


### PR DESCRIPTION
Also removes the second default Elasticsearch host.