### PR TITLE
[TASK] Require ext-curl in composer manifest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "type": "typo3-flow-package",
     "description": "This package provides wrapper functionality for the elasticsearch engine.",
     "require": {
+        "ext-curl": "*",
         "typo3/flow": "*"
     },
     "autoload": {


### PR DESCRIPTION
The curl PHP extension is used and thus this change marks it as required
in the composer manifest.