### PR TITLE
[BUGFIX] Assign array key to doctrine event listener

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -17,6 +17,6 @@ TYPO3:
     persistence:
       doctrine:
         eventListeners:
-          -
+          'Flowpack\ElasticSearch\Indexer\Object\Signal\Doctrine\EmitterAdapter':
             events: ['postUpdate', 'postPersist', 'postRemove']
             listener: 'Flowpack\ElasticSearch\Indexer\Object\Signal\Doctrine\EmitterAdapter'


### PR DESCRIPTION
Because of the unkeyed array (using "-"), Flow will merge the array of
setting TYPO3.Flow.persistence.doctrine.eventListeners with another
unkeyed array from another package which will cause issue that the last
package's setting will override the previous ones.