### PR TITLE
[Bugfix] Remove checking of HandledObjects

### DIFF
--- a/Classes/Flowpack/ElasticSearch/Indexer/Object/ObjectIndexer.php
+++ b/Classes/Flowpack/ElasticSearch/Indexer/Object/ObjectIndexer.php
@@ -64,13 +64,6 @@ class ObjectIndexer {
 	protected $client;
 
 	/**
-	 * Stores the objects which are already indexed in order to avoid duplicate indexing due to multiple notifications, for example
-	 *
-	 * @var array
-	 */
-	protected $handledObjects = array();
-
-	/**
 	 * (Re-) indexes an object to the ElasticSearch index, no matter if the change is actually required.
 	 *
 	 * @param object $object
@@ -80,12 +73,6 @@ class ObjectIndexer {
 	 * @return void
 	 */
 	public function indexObject($object, $signalInformation = NULL, Client $client = NULL) {
-		$objectHash = spl_object_hash($object);
-		if (isset($this->handledObjects[$objectHash])) {
-			return;
-		}
-		$this->handledObjects[$objectHash] = true;
-
 		$type = $this->getIndexTypeForObject($object, $client);
 		if ($type === NULL) {
 			return NULL;
@@ -124,12 +111,6 @@ class ObjectIndexer {
 	 * @param \Flowpack\ElasticSearch\Domain\Model\Client $client
 	 */
 	public function removeObject($object, $signalInformation = NULL, Client $client = NULL) {
-		$objectHash = spl_object_hash($object);
-		if (isset($this->handledObjects[$objectHash])) {
-			return;
-		}
-		$this->handledObjects[$objectHash] = true;
-
 		$type = $this->getIndexTypeForObject($object, $client);
 		if ($type === NULL) {
 			return;


### PR DESCRIPTION
This bugfix removes the handledObjects checking from ObjectIndexer. After "[TASK] Don't keep the full object in handledObjects property", which was neccessary to reduce the memory usage when indexing huge amount of objects, the handledObjects checking prevents indexing. 

This happens, because the method spl_object_hash is used to generate a unique identifier. As the documentation states "This id can be used as a hash key for storing objects, or for identifying an object, as long as the object is not destroyed", but in fact, this is exactly what we wanted to achieve: Destroy the objects after indexing.

Otherwise it would be possible to use the PersistanceManager to get the unique identifier, but this would prevent non persistent objects from being indexed in ElasticSearch. I think this may be a rare case, but it should be possible.

In my opinion, better index twice then silently don't index .