### PR TITLE
[FEATURE] Support username / password for SaaS Elasticsearch

### DIFF
--- a/Classes/Flowpack/ElasticSearch/Domain/Model/Client/ClientConfiguration.php
+++ b/Classes/Flowpack/ElasticSearch/Domain/Model/Client/ClientConfiguration.php
@@ -34,6 +34,16 @@ class ClientConfiguration
     protected $scheme = 'http';
 
     /**
+     * @var string
+     */
+    protected $username = '';
+
+    /**
+     * @var string
+     */
+    protected $password = '';
+
+    /**
      * @param string $host
      */
     public function setHost($host)
@@ -82,6 +92,48 @@ class ClientConfiguration
     }
 
     /**
+     * Returns username
+     *
+     * @return string
+     */
+    public function getUsername()
+    {
+        return $this->username;
+    }
+
+    /**
+     * Sets username
+     *
+     * @param string $username
+     * @return void
+     */
+    public function setUsername($username)
+    {
+        $this->username = $username;
+    }
+
+    /**
+     * Returns password
+     *
+     * @return string
+     */
+    public function getPassword()
+    {
+        return $this->password;
+    }
+
+    /**
+     * Sets password
+     *
+     * @param string $password
+     * @return void
+     */
+    public function setPassword($password)
+    {
+        $this->password = $password;
+    }
+
+    /**
      * @return \TYPO3\Flow\Http\Uri
      */
     public function getUri()
@@ -90,6 +142,8 @@ class ClientConfiguration
         $uri->setScheme($this->scheme);
         $uri->setHost($this->host);
         $uri->setPort($this->port);
+        $uri->setUsername($this->username);
+        $uri->setPassword($this->password);
 
         return $uri;
     }

--- a/Classes/Flowpack/ElasticSearch/Transfer/RequestService.php
+++ b/Classes/Flowpack/ElasticSearch/Transfer/RequestService.php
@@ -69,6 +69,12 @@ class RequestService
             $uri->setPath($uri->getPath() . $path);
         }
 
+        if ($uri->getUsername()) {
+            $requestEngine = $this->browser->getRequestEngine();
+            $requestEngine->setOption(CURLOPT_USERPWD, $uri->getUsername() . ':' . $uri->getPassword() );
+            $requestEngine->setOption(CURLOPT_HTTPAUTH, CURLAUTH_BASIC);
+        }
+
         $response = $this->browser->request($uri, $method, $arguments, array(), array(),
             is_array($content) ? json_encode($content) : $content);
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -5,6 +5,8 @@ Flowpack:
       default:
         - host: localhost
           port: 9200
+          username: ''
+          password: ''
 
     realtimeIndexing:
       enabled: TRUE

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -33,6 +33,19 @@ have a dedicated server (recommended) for running the Functional Tests, set it u
 
 During runtime, you have to provide the client's name you want to connect to, if it is not `default`.
 
+When access to the Elasticsearch instance is protected through HTTP Basic Auth, you can provide the necessary username
+and password in your client settings::
+
+ 	Flowpack:
+	  ElasticSearch:
+	    clients:
+	        # default bundle that will be used if no more specific bundle name was supplied.
+	      default:
+	        - host: localhost
+	          port: 9200
+	          username: john
+	          password: mysecretpassword
+
 Running the Functional Tests
 ============================
 

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -36,7 +36,7 @@ During runtime, you have to provide the client's name you want to connect to, if
 When access to the Elasticsearch instance is protected through HTTP Basic Auth, you can provide the necessary username
 and password in your client settings::
 
- 	Flowpack:
+	Flowpack:
 	  ElasticSearch:
 	    clients:
 	        # default bundle that will be used if no more specific bundle name was supplied.


### PR DESCRIPTION
This change adds the two new client settings options "username" and
"password" which allows for setting credentials being integrated into
the request URL when accessing Elasticsearch instances protected by
HTTP Basic Auth.