### PR TITLE
[BUGFIX] Request drops username / password in some cases

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -41,8 +41,9 @@ and password in your client settings::
 	    clients:
 	        # default bundle that will be used if no more specific bundle name was supplied.
 	      default:
-	        - host: localhost
-	          port: 9200
+	        - host: my.elasticsearch-service.com
+	          port: 443
+	          scheme: https
 	          username: john
 	          password: mysecretpassword
 


### PR DESCRIPTION
This change makes the RequestService more resilient for some cases when
the HTTP Request sent to Elasticsearch did not contain the username
and password anymore, even though it has been configured in the
settings.

While the root cause is the Http\Request::create() method in Flow,
this change at least provides a workaround which allows for connecting
with Elasticsearch instances protected with HTTP Basic Auth.

Also circumvents a rare case where the content of a PUT request contains
"null" as a string.