### PR TITLE
[BUGFIX] Fix exception rendering on failed request

### DIFF
--- a/Classes/Flowpack/ElasticSearch/Transfer/Exception.php
+++ b/Classes/Flowpack/ElasticSearch/Transfer/Exception.php
@@ -34,7 +34,7 @@ class Exception extends \Flowpack\ElasticSearch\Exception
         $this->response = $response;
         $this->request = $request;
         if ($request !== null) {
-            $message = sprintf("[%s %s]: %s\n\nRequest data: %s",
+            $message = sprintf("Elasticsearch request failed.\n[%s %s]: %s\n\nRequest data: %s",
                 $request->getMethod(),
                 $request->getUri(),
                 $message . '; Response body: ' . $response->getContent(),

--- a/Classes/Flowpack/ElasticSearch/Transfer/Response.php
+++ b/Classes/Flowpack/ElasticSearch/Transfer/Response.php
@@ -47,7 +47,8 @@ class Response
             }
 
             if (array_key_exists('error', $treatedContent)) {
-                throw new Exception\ApiException($treatedContent['error'], 1338977435, $response, $request);
+                $exceptionMessage = print_r($treatedContent['error'], true);
+                throw new Exception\ApiException($exceptionMessage, 1338977435, $response, $request);
             }
         }
 

--- a/Tests/Functional/Fixtures/TweetRepository.php
+++ b/Tests/Functional/Fixtures/TweetRepository.php
@@ -17,6 +17,6 @@ use TYPO3\Flow\Annotations as Flow;
 /**
  * @Flow\Scope("singleton")
  */
-class TweetRepository  extends \TYPO3\Flow\Persistence\Repository
+class TweetRepository extends \TYPO3\Flow\Persistence\Repository
 {
 }


### PR DESCRIPTION
If a request to elasticsearch fails, for example in case of a
missing request, the error part of the ES response array is set
as the exception message which is then tried to be rendered
as part of the message and raises an exception due to array
string conversion.