### PR TITLE
BUGFIX: Support get arguments in API request

### DIFF
--- a/Classes/Flowpack/ElasticSearch/Transfer/RequestService.php
+++ b/Classes/Flowpack/ElasticSearch/Transfer/RequestService.php
@@ -69,6 +69,10 @@ class RequestService
 
         $uri = clone $clientConfiguration->getUri();
         if ($path !== null) {
+            if (strpos($path, '?') !== false) {
+                list($path, $query) = explode('?', $path);
+                $uri->setQuery($query);
+            }
             $uri->setPath($uri->getPath() . $path);
         }
 


### PR DESCRIPTION
This change allow to call ElasticSearch with get arguments:

    $this->getIndex()->request('GET', '/_search/scroll?scroll=1m');

This is required because some ElasticSearch API argument are only
available as GET request arguments.