### PR TITLE
BUGFIX: Signal based indexing is triggered again

### DIFF
--- a/Classes/Flowpack/ElasticSearch/Package.php
+++ b/Classes/Flowpack/ElasticSearch/Package.php
@@ -35,7 +35,7 @@ class Package extends BasePackage
         $dispatcher = $bootstrap->getSignalSlotDispatcher();
         $package = $this;
         $dispatcher->connect('TYPO3\Flow\Core\Booting\Sequence', 'afterInvokeStep', function (\TYPO3\Flow\Core\Booting\Step $step) use ($package, $bootstrap) {
-            if ($step->getIdentifier() === 'typo3.flow:persistence') {
+            if ($step->getIdentifier() === 'typo3.flow:objectmanagement:runtime') {
                 $package->prepareRealtimeIndexing($bootstrap);
             }
         });


### PR DESCRIPTION
Since the boot step that was used no longer exists for a while the
realtime indexing via signals was never initalized and didn't work.
This change uses an existing boot step identifier to bind the
signals so that using them has the desired effect.