### PR TITLE
TASK: Clean up code and tests

### DIFF
--- a/Classes/Flowpack/ElasticSearch/Command/IndexCommandController.php
+++ b/Classes/Flowpack/ElasticSearch/Command/IndexCommandController.php
@@ -56,6 +56,7 @@ class IndexCommandController extends \TYPO3\Flow\Cli\CommandController
      *
      * @param string $indexName The name of the new index
      * @param string $clientName The client name to use
+     * @return void
      */
     public function createCommand($indexName, $clientName = null)
     {
@@ -84,6 +85,7 @@ class IndexCommandController extends \TYPO3\Flow\Cli\CommandController
      *
      * @param string $indexName The name of the new index
      * @param string $clientName The client name to use
+     * @return void
      */
     public function updateSettingsCommand($indexName, $clientName = null)
     {
@@ -112,6 +114,7 @@ class IndexCommandController extends \TYPO3\Flow\Cli\CommandController
      *
      * @param string $indexName The name of the index to be removed
      * @param string $clientName The client name to use
+     * @return void
      */
     public function deleteCommand($indexName, $clientName = null)
     {
@@ -140,6 +143,7 @@ class IndexCommandController extends \TYPO3\Flow\Cli\CommandController
      *
      * @param string $indexName The name of the index to be removed
      * @param string $clientName The client name to use
+     * @return void
      */
     public function refreshCommand($indexName, $clientName = null)
     {
@@ -164,6 +168,8 @@ class IndexCommandController extends \TYPO3\Flow\Cli\CommandController
 
     /**
      * List available document type
+     *
+     * @return void
      */
     public function showConfiguredTypesCommand()
     {
@@ -181,6 +187,7 @@ class IndexCommandController extends \TYPO3\Flow\Cli\CommandController
      * @param string $object Class name of a domain object. If given, will only work on this single object
      * @param boolean $conductUpdate Set to TRUE to conduct the required corrections
      * @param string $clientName The client name to use
+     * @return void
      */
     public function statusCommand($object = null, $conductUpdate = false, $clientName = null)
     {
@@ -258,7 +265,6 @@ class IndexCommandController extends \TYPO3\Flow\Cli\CommandController
     /**
      * @param Client $client
      * @param string $className
-     *
      * @return array
      */
     protected function getModificationsNeededStatesAndIdentifiers(Client $client, $className)

--- a/Classes/Flowpack/ElasticSearch/Command/MappingCommandController.php
+++ b/Classes/Flowpack/ElasticSearch/Command/MappingCommandController.php
@@ -11,6 +11,7 @@ namespace Flowpack\ElasticSearch\Command;
  * source code.
  */
 
+use Flowpack\ElasticSearch\Mapping\MappingCollection;
 use TYPO3\Flow\Annotations as Flow;
 
 /**
@@ -178,11 +179,11 @@ class MappingCommandController extends \TYPO3\Flow\Cli\CommandController
     /**
      * Traverses through mappingInformation array and aggregates by index and type names
      *
-     * @param \Flowpack\ElasticSearch\Mapping\MappingCollection $mappingCollection
+     * @param MappingCollection $mappingCollection
      * @throws \Flowpack\ElasticSearch\Exception
      * @return array with index names as keys, second level type names as keys
      */
-    protected function buildArrayFromMappingCollection(\Flowpack\ElasticSearch\Mapping\MappingCollection $mappingCollection)
+    protected function buildArrayFromMappingCollection(MappingCollection $mappingCollection)
     {
         $return = array();
 

--- a/Classes/Flowpack/ElasticSearch/Domain/Exception/DocumentPropertiesMismatchException.php
+++ b/Classes/Flowpack/ElasticSearch/Domain/Exception/DocumentPropertiesMismatchException.php
@@ -11,20 +11,23 @@ namespace Flowpack\ElasticSearch\Domain\Exception;
  * source code.
  */
 
+use TYPO3\Flow\Error\Result;
+
 /**
  * Signals a mismatch between the
  */
 class DocumentPropertiesMismatchException extends \Flowpack\ElasticSearch\Exception
 {
     /**
-     * @var \TYPO3\Flow\Error\Result
+     * @var Result
      */
     protected $errorResult;
 
     /**
-     * @param \TYPO3\Flow\Error\Result $result
+     * @param Result $result
+     * @return void
      */
-    public function setErrorResult(\TYPO3\Flow\Error\Result $result)
+    public function setErrorResult(Result $result)
     {
         $this->errorResult = $result;
     }

--- a/Classes/Flowpack/ElasticSearch/Domain/Factory/ClientFactory.php
+++ b/Classes/Flowpack/ElasticSearch/Domain/Factory/ClientFactory.php
@@ -37,6 +37,7 @@ class ClientFactory
      * @param string $clientClassName
      * @throws \Flowpack\ElasticSearch\Exception
      * @return \Flowpack\ElasticSearch\Domain\Model\Client
+     * @return void
      */
     public function create($bundle = null, $clientClassName = 'Flowpack\ElasticSearch\Domain\Model\Client')
     {
@@ -59,12 +60,11 @@ class ClientFactory
     }
 
     /**
-     * @param $clientsSettings
-     *
+     * @param array $clientsSettings
      * @return array
      * @throws \Flowpack\ElasticSearch\Exception
      */
-    protected function buildClientConfigurations($clientsSettings)
+    protected function buildClientConfigurations(array $clientsSettings)
     {
         $clientConfigurations = array();
         foreach ($clientsSettings as $clientSettings) {

--- a/Classes/Flowpack/ElasticSearch/Domain/Model/AbstractType.php
+++ b/Classes/Flowpack/ElasticSearch/Domain/Model/AbstractType.php
@@ -70,8 +70,7 @@ abstract class AbstractType
     /**
      * Returns a document
      *
-     * @param $id
-     *
+     * @param string $id
      * @return \Flowpack\ElasticSearch\Domain\Model\Document
      */
     public function findDocumentById($id)
@@ -86,7 +85,7 @@ abstract class AbstractType
     }
 
     /**
-     * @param $id
+     * @param string $id
      * @return boolean ...whether the deletion is considered successful
      */
     public function deleteDocumentById($id)
@@ -125,10 +124,9 @@ abstract class AbstractType
      * @param string $path
      * @param array $arguments
      * @param string $content
-     *
      * @return \Flowpack\ElasticSearch\Transfer\Response
      */
-    public function request($method, $path = null, $arguments = array(), $content = null)
+    public function request($method, $path = null, array $arguments = array(), $content = null)
     {
         $path = '/' . $this->name . ($path ?: '');
 

--- a/Classes/Flowpack/ElasticSearch/Domain/Model/Client.php
+++ b/Classes/Flowpack/ElasticSearch/Domain/Model/Client.php
@@ -91,10 +91,9 @@ class Client
      * @param string $path
      * @param array $arguments
      * @param string|array $content
-     *
      * @return \Flowpack\ElasticSearch\Transfer\Response
      */
-    public function request($method, $path = null, $arguments = array(), $content = null)
+    public function request($method, $path = null, array $arguments = array(), $content = null)
     {
         return $this->requestService->request($method, $this, $path, $arguments, $content);
     }

--- a/Classes/Flowpack/ElasticSearch/Domain/Model/Client/ClientConfiguration.php
+++ b/Classes/Flowpack/ElasticSearch/Domain/Model/Client/ClientConfiguration.php
@@ -45,6 +45,7 @@ class ClientConfiguration
 
     /**
      * @param string $host
+     * @return void
      */
     public function setHost($host)
     {
@@ -61,6 +62,7 @@ class ClientConfiguration
 
     /**
      * @param int $port
+     * @return void
      */
     public function setPort($port)
     {
@@ -77,6 +79,7 @@ class ClientConfiguration
 
     /**
      * @param string $scheme
+     * @return void
      */
     public function setScheme($scheme)
     {

--- a/Classes/Flowpack/ElasticSearch/Domain/Model/Document.php
+++ b/Classes/Flowpack/ElasticSearch/Domain/Model/Document.php
@@ -19,7 +19,7 @@ use TYPO3\Flow\Annotations as Flow;
 class Document
 {
     /**
-     * @var \Flowpack\ElasticSearch\Domain\Model\AbstractType
+     * @var AbstractType
      */
     protected $type;
 
@@ -52,10 +52,10 @@ class Document
     protected $dirty = true;
 
     /**
-     * @param \Flowpack\ElasticSearch\Domain\Model\AbstractType $type
+     * @param AbstractType $type
      * @param array $data
      * @param string $id
-     * @param null $version
+     * @param integer $version
      */
     public function __construct(AbstractType $type, array $data = null, $id = null, $version = null)
     {
@@ -68,6 +68,8 @@ class Document
     /**
      * When cloning (locally), the cloned object doesn't represent a stored one anymore,
      * so reset id, version and the dirty state.
+     *
+     * @return void
      */
     public function __clone()
     {
@@ -81,10 +83,9 @@ class Document
      * @param string $path
      * @param array $arguments
      * @param string $content
-     *
      * @return \Flowpack\ElasticSearch\Transfer\Response
      */
-    protected function request($method, $path = null, $arguments = array(), $content = null)
+    protected function request($method, $path = null, array $arguments = array(), $content = null)
     {
         return $this->type->request($method, $path, $arguments, $content);
     }
@@ -114,6 +115,7 @@ class Document
 
     /**
      * @param boolean $dirty
+     * @return void
      */
     protected function setDirty($dirty = true)
     {
@@ -148,8 +150,9 @@ class Document
 
     /**
      * @param array $data
+     * @return void
      */
-    public function setData($data)
+    public function setData(array $data)
     {
         $this->data = $data;
         $this->setDirty();
@@ -168,7 +171,6 @@ class Document
      *
      * @param string $fieldName
      * @param boolean $silent
-     *
      * @throws \Flowpack\ElasticSearch\Exception
      * @return mixed
      */
@@ -182,7 +184,7 @@ class Document
     }
 
     /**
-     * @return \Flowpack\ElasticSearch\Domain\Model\AbstractType the type of this Document
+     * @return AbstractType the type of this Document
      */
     public function getType()
     {

--- a/Classes/Flowpack/ElasticSearch/Domain/Model/GenericType.php
+++ b/Classes/Flowpack/ElasticSearch/Domain/Model/GenericType.php
@@ -19,7 +19,7 @@ use TYPO3\Flow\Annotations as Flow;
 class GenericType extends AbstractType
 {
     /**
-     * @param \Flowpack\ElasticSearch\Domain\Model\Index $index
+     * @param Index $index
      * @param string $name
      */
     public function __construct(Index $index, $name)

--- a/Classes/Flowpack/ElasticSearch/Domain/Model/Index.php
+++ b/Classes/Flowpack/ElasticSearch/Domain/Model/Index.php
@@ -96,7 +96,6 @@ class Index
     /**
      * @param $name
      * @param Client $client $client
-     *
      * @throws \Flowpack\ElasticSearch\Exception
      */
     public function __construct($name, Client $client = null)
@@ -113,7 +112,7 @@ class Index
     }
 
     /**
-     * @param $typeName
+     * @param string $typeName
      * @return \Flowpack\ElasticSearch\Domain\Model\AbstractType
      */
     public function findType($typeName)
@@ -123,7 +122,6 @@ class Index
 
     /**
      * @param array<AbstractType> $types
-     *
      * @return TypeGroup
      */
     public function findTypeGroup(array $types)
@@ -189,11 +187,10 @@ class Index
      * @param array $arguments
      * @param string $content
      * @param boolean $prefixIndex
-     *
-     * @throws \Flowpack\ElasticSearch\Exception
      * @return \Flowpack\ElasticSearch\Transfer\Response
+     * @throws \Flowpack\ElasticSearch\Exception
      */
-    public function request($method, $path = null, $arguments = array(), $content = null, $prefixIndex = true)
+    public function request($method, $path = null, array $arguments = array(), $content = null, $prefixIndex = true)
     {
         if ($this->client === null) {
             throw new Exception('The client of the index "' . $this->name . '" is not set, hence no requests can be done.');
@@ -218,6 +215,7 @@ class Index
 
     /**
      * @param Client $client
+     * @return void
      */
     public function setClient($client)
     {
@@ -225,7 +223,8 @@ class Index
     }
 
     /**
-     * @param $settingsKey
+     * @param string $settingsKey
+     * @return void
      */
     public function setSettingsKey($settingsKey)
     {

--- a/Classes/Flowpack/ElasticSearch/Domain/Model/Mapping.php
+++ b/Classes/Flowpack/ElasticSearch/Domain/Model/Mapping.php
@@ -20,7 +20,7 @@ use TYPO3\Flow\Utility\Arrays;
 class Mapping
 {
     /**
-     * @var \Flowpack\ElasticSearch\Domain\Model\AbstractType
+     * @var AbstractType
      */
     protected $type;
 
@@ -45,7 +45,7 @@ class Mapping
     protected $fullMapping = array();
 
     /**
-     * @param \Flowpack\ElasticSearch\Domain\Model\AbstractType $type
+     * @param AbstractType $type
      */
     public function __construct(AbstractType $type)
     {
@@ -60,7 +60,7 @@ class Mapping
      */
     public function getPropertyByPath($path)
     {
-        return \TYPO3\Flow\Utility\Arrays::getValueByPath($this->properties, $path);
+        return Arrays::getValueByPath($this->properties, $path);
     }
 
     /**
@@ -72,7 +72,7 @@ class Mapping
      */
     public function setPropertyByPath($path, $value)
     {
-        $this->properties = \TYPO3\Flow\Utility\Arrays::setValueByPath($this->properties, $path, $value);
+        $this->properties = Arrays::setValueByPath($this->properties, $path, $value);
     }
 
     /**
@@ -84,7 +84,7 @@ class Mapping
     }
 
     /**
-     * @return \Flowpack\ElasticSearch\Domain\Model\AbstractType
+     * @return AbstractType
      */
     public function getType()
     {
@@ -106,6 +106,8 @@ class Mapping
 
     /**
      * Sets this mapping to the server
+     *
+     * @return \Flowpack\ElasticSearch\Transfer\Response
      */
     public function apply()
     {
@@ -126,8 +128,9 @@ class Mapping
     /**
      * Dynamic templates allow to define mapping templates
      *
-     * @param $dynamicTemplateName
+     * @param string $dynamicTemplateName
      * @param array $mappingConfiguration
+     * @return void
      */
     public function addDynamicTemplate($dynamicTemplateName, array $mappingConfiguration)
     {
@@ -142,6 +145,7 @@ class Mapping
      * It can be used to specify arbitrary ElasticSearch mapping options, like f.e. configuring the _all field.
      *
      * @param array $fullMapping
+     * @return void
      */
     public function setFullMapping(array $fullMapping)
     {
@@ -149,7 +153,8 @@ class Mapping
     }
 
     /**
-     * see {@link setFullMapping} for documentation
+     * See {@link setFullMapping} for documentation
+     *
      * @return array
      */
     public function getFullMapping()

--- a/Classes/Flowpack/ElasticSearch/Indexer/Object/IndexInformer.php
+++ b/Classes/Flowpack/ElasticSearch/Indexer/Object/IndexInformer.php
@@ -40,6 +40,7 @@ class IndexInformer
     protected $indexAnnotations = array();
 
     /**
+     * @return void
      */
     public function initializeObject()
     {
@@ -112,18 +113,18 @@ class IndexInformer
      * The annotation contains the class's annotation, while properties contains each property that has to be indexed.
      * Each property might either have TRUE as value, or also an annotation instance, if given.
      *
-     * @throws \Flowpack\ElasticSearch\Exception
      * @param ObjectManagerInterface $objectManager
      * @return array
+     * @throws \Flowpack\ElasticSearch\Exception
      */
     public static function buildIndexClassesAndProperties($objectManager)
     {
         /** @var ReflectionService $reflectionService */
-        $reflectionService = $objectManager->get('TYPO3\Flow\Reflection\ReflectionService');
+        $reflectionService = $objectManager->get(\TYPO3\Flow\Reflection\ReflectionService::class);
 
         $indexAnnotations = array();
 
-        $annotationClassName = 'Flowpack\ElasticSearch\Annotations\Indexable';
+        $annotationClassName = \Flowpack\ElasticSearch\Annotations\Indexable::class;
         foreach ($reflectionService->getClassNamesByAnnotation($annotationClassName) as $className) {
             if ($reflectionService->isClassAbstract($className)) {
                 throw new \Flowpack\ElasticSearch\Exception(sprintf('The class with name "%s" is annotated with %s, but is abstract. Indexable classes must not be abstract.', $className, $annotationClassName), 1339595182);

--- a/Classes/Flowpack/ElasticSearch/Indexer/Object/Transform/DateTransformer.php
+++ b/Classes/Flowpack/ElasticSearch/Indexer/Object/Transform/DateTransformer.php
@@ -31,7 +31,6 @@ class DateTransformer implements TransformerInterface
     /**
      * @param \DateTime $source
      * @param \Flowpack\ElasticSearch\Annotations\Transform $annotation
-     *
      * @return string
      */
     public function transformByAnnotation($source, \Flowpack\ElasticSearch\Annotations\Transform $annotation)

--- a/Classes/Flowpack/ElasticSearch/Indexer/Object/Transform/TransformerFactory.php
+++ b/Classes/Flowpack/ElasticSearch/Indexer/Object/Transform/TransformerFactory.php
@@ -27,9 +27,8 @@ class TransformerFactory
 
     /**
      * @param string $annotatedTransformer Either a full qualified class name or a shortened one which is seeked in the current package.
-     *
-     * @throws \Flowpack\ElasticSearch\Exception
      * @return \Flowpack\ElasticSearch\Indexer\Object\Transform\TransformerInterface
+     * @throws \Flowpack\ElasticSearch\Exception
      */
     public function create($annotatedTransformer)
     {

--- a/Classes/Flowpack/ElasticSearch/Mapping/BackendMappingBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/Mapping/BackendMappingBuilder.php
@@ -23,7 +23,7 @@ use TYPO3\Flow\Annotations as Flow;
 class BackendMappingBuilder
 {
     /**
-     * @var \Flowpack\ElasticSearch\Domain\Model\Client
+     * @var Model\Client
      */
     protected $client;
 
@@ -44,8 +44,8 @@ class BackendMappingBuilder
     /**
      * Builds a Mapping collection from the annotation sources that are present
      *
-     * @throws \Flowpack\ElasticSearch\Exception
      * @return \Flowpack\ElasticSearch\Mapping\MappingCollection<\Flowpack\ElasticSearch\Domain\Model\Mapping>
+     * @throws \Flowpack\ElasticSearch\Exception
      */
     public function buildMappingInformation()
     {
@@ -86,7 +86,8 @@ class BackendMappingBuilder
     }
 
     /**
-     * @param \Flowpack\ElasticSearch\Domain\Model\Client $client
+     * @param Model\Client $client
+     * @return void
      */
     public function setClient(Model\Client $client)
     {
@@ -94,8 +95,8 @@ class BackendMappingBuilder
     }
 
     /**
-     * @throws \Flowpack\ElasticSearch\Exception
      * @return array
+     * @throws \Flowpack\ElasticSearch\Exception
      */
     public function getIndicesWithoutTypeInformation()
     {

--- a/Classes/Flowpack/ElasticSearch/Mapping/EntityMappingBuilder.php
+++ b/Classes/Flowpack/ElasticSearch/Mapping/EntityMappingBuilder.php
@@ -11,6 +11,7 @@ namespace Flowpack\ElasticSearch\Mapping;
  * source code.
  */
 
+use Flowpack\ElasticSearch\Annotations\Indexable as IndexableAnnotation;
 use Flowpack\ElasticSearch\Annotations\Mapping as MappingAnnotation;
 use Flowpack\ElasticSearch\Domain\Model\Mapping;
 use TYPO3\Flow\Annotations as Flow;
@@ -63,10 +64,10 @@ class EntityMappingBuilder
 
     /**
      * @param string $className
-     * @param \Flowpack\ElasticSearch\Annotations\Indexable $annotation
+     * @param IndexableAnnotation $annotation
      * @return Mapping
      */
-    protected function buildMappingFromClassAndAnnotation($className, \Flowpack\ElasticSearch\Annotations\Indexable $annotation)
+    protected function buildMappingFromClassAndAnnotation($className, IndexableAnnotation $annotation)
     {
         $index = new \Flowpack\ElasticSearch\Domain\Model\Index($annotation->indexName);
         $type = new \Flowpack\ElasticSearch\Domain\Model\GenericType($index, $annotation->typeName);
@@ -82,9 +83,8 @@ class EntityMappingBuilder
      * @param Mapping $mapping
      * @param string $className
      * @param string $propertyName
-     *
-     * @throws \Flowpack\ElasticSearch\Exception
      * @return void
+     * @throws \Flowpack\ElasticSearch\Exception
      */
     protected function augmentMappingByProperty(Mapping $mapping, $className, $propertyName)
     {
@@ -106,6 +106,7 @@ class EntityMappingBuilder
         if ($annotation instanceof MappingAnnotation) {
             $mapping->setPropertyByPath($propertyName, $this->processMappingAnnotation($annotation, $mapping->getPropertyByPath($propertyName)));
             if ($annotation->getFields()) {
+                $multiFields = [];
                 foreach ($annotation->getFields() as $multiFieldAnnotation) {
                     $multiFieldIndexName = trim($multiFieldAnnotation->index_name);
                     if ($multiFieldIndexName === '') {
@@ -127,7 +128,7 @@ class EntityMappingBuilder
      * @param array $propertyMapping
      * @return array
      */
-    protected function processMappingAnnotation(MappingAnnotation $annotation, $propertyMapping = array())
+    protected function processMappingAnnotation(MappingAnnotation $annotation, array $propertyMapping = array())
     {
         foreach ($annotation->getPropertiesArray() as $mappingDirective => $directiveValue) {
             if ($directiveValue === null) {

--- a/Classes/Flowpack/ElasticSearch/Mapping/MappingCollection.php
+++ b/Classes/Flowpack/ElasticSearch/Mapping/MappingCollection.php
@@ -12,6 +12,7 @@ namespace Flowpack\ElasticSearch\Mapping;
  */
 
 use Doctrine\ORM\Mapping as ORM;
+use Flowpack\ElasticSearch\Domain\Model\Mapping;
 use TYPO3\Flow\Annotations as Flow;
 
 /**
@@ -52,8 +53,8 @@ class MappingCollection extends \Doctrine\Common\Collections\ArrayCollection
     {
         $returnMappings = new \Flowpack\ElasticSearch\Mapping\MappingCollection();
         foreach ($this as $entityMapping) {
-            /** @var $entityMapping \Flowpack\ElasticSearch\Domain\Model\Mapping */
-            $mapping = new \Flowpack\ElasticSearch\Domain\Model\Mapping(clone $entityMapping->getType());
+            /** @var $entityMapping Mapping */
+            $mapping = new Mapping(clone $entityMapping->getType());
             $saveMapping = false;
             foreach ($entityMapping->getProperties() as $propertyName => $propertySettings) {
                 foreach ($propertySettings as $entitySettingKey => $entitySettingValue) {
@@ -75,16 +76,15 @@ class MappingCollection extends \Doctrine\Common\Collections\ArrayCollection
     /**
      * Tells whether a member of this collection has a specific index/type/property settings value
      *
-     * @param \Flowpack\ElasticSearch\Domain\Model\Mapping $inquirerMapping
+     * @param Mapping $inquirerMapping
      * @param string $propertyName
-     * @param $settingKey
-     *
+     * @param string $settingKey
      * @return mixed
      */
-    public function getMappingSetting(\Flowpack\ElasticSearch\Domain\Model\Mapping $inquirerMapping, $propertyName, $settingKey)
+    public function getMappingSetting(Mapping $inquirerMapping, $propertyName, $settingKey)
     {
         foreach ($this as $memberMapping) {
-            /** @var $memberMapping \Flowpack\ElasticSearch\Domain\Model\Mapping */
+            /** @var $memberMapping Mapping */
             if ($inquirerMapping->getType()->getName() === $memberMapping->getType()->getName()
                 && $inquirerMapping->getType()->getIndex()->getName() === $memberMapping->getType()->getIndex()->getName()) {
                 return $memberMapping->getPropertyByPath(array($propertyName, $settingKey));
@@ -96,6 +96,7 @@ class MappingCollection extends \Doctrine\Common\Collections\ArrayCollection
 
     /**
      * @param \Flowpack\ElasticSearch\Domain\Model\Client $client
+     * @return void
      */
     public function setClient(\Flowpack\ElasticSearch\Domain\Model\Client $client)
     {

--- a/Classes/Flowpack/ElasticSearch/Transfer/Exception.php
+++ b/Classes/Flowpack/ElasticSearch/Transfer/Exception.php
@@ -27,7 +27,13 @@ class Exception extends \Flowpack\ElasticSearch\Exception
     protected $request;
 
     /**
+     * Exception constructor.
      *
+     * @param string $message
+     * @param integer $code
+     * @param \TYPO3\Flow\Http\Response $response
+     * @param \TYPO3\Flow\Http\Request $request
+     * @param \Exception $previous
      */
     public function __construct($message, $code, \TYPO3\Flow\Http\Response $response, \TYPO3\Flow\Http\Request $request = null, \Exception $previous = null)
     {

--- a/Classes/Flowpack/ElasticSearch/Transfer/RequestService.php
+++ b/Classes/Flowpack/ElasticSearch/Transfer/RequestService.php
@@ -18,6 +18,7 @@ use TYPO3\Flow\Http\Request;
 
 /**
  * Handles the requests
+ *
  * @Flow\scope("singleton")
  */
 class RequestService
@@ -58,8 +59,7 @@ class RequestService
      * @param string $path
      * @param array $arguments
      * @param string|array $content
-     *
-     * @return \Flowpack\ElasticSearch\Transfer\Response
+     * @return Response
      */
     public function request($method, \Flowpack\ElasticSearch\Domain\Model\Client $client, $path = null, $arguments = array(), $content = null)
     {

--- a/Classes/Flowpack/ElasticSearch/Transfer/Response.php
+++ b/Classes/Flowpack/ElasticSearch/Transfer/Response.php
@@ -31,7 +31,6 @@ class Response
     /**
      * @param \TYPO3\Flow\Http\Response $response
      * @param \TYPO3\Flow\Http\Request $request
-     *
      * @throws \Flowpack\ElasticSearch\Transfer\Exception
      * @throws \Flowpack\ElasticSearch\Transfer\Exception\ApiException
      */

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Neos project contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Tests/Functional/Domain/AbstractTest.php
+++ b/Tests/Functional/Domain/AbstractTest.php
@@ -11,12 +11,14 @@ namespace Flowpack\ElasticSearch\Tests\Functional\Domain;
  * source code.
  */
 
+use Flowpack\ElasticSearch\Domain\Factory\ClientFactory;
+
 /**
  */
 abstract class AbstractTest extends \TYPO3\Flow\Tests\FunctionalTestCase
 {
     /**
-     * @var \Flowpack\ElasticSearch\Domain\Factory\ClientFactory
+     * @var ClientFactory
      */
     protected $clientFactory;
 
@@ -37,7 +39,7 @@ abstract class AbstractTest extends \TYPO3\Flow\Tests\FunctionalTestCase
     {
         parent::setUp();
 
-        $this->clientFactory = $this->objectManager->get('Flowpack\ElasticSearch\Domain\Factory\ClientFactory');
+        $this->clientFactory = $this->objectManager->get(ClientFactory::class);
         $client = $this->clientFactory->create();
         $this->testingIndex = $client->findIndex('typo3_elasticsearch_functionaltests');
 

--- a/Tests/Functional/Domain/DocumentTest.php
+++ b/Tests/Functional/Domain/DocumentTest.php
@@ -11,6 +11,7 @@ namespace Flowpack\ElasticSearch\Tests\Functional\Domain;
  * source code.
  */
 
+use Flowpack\ElasticSearch\Domain\Model\Document;
 use \Flowpack\ElasticSearch\Tests\Functional\Fixtures\TwitterType;
 
 /**
@@ -40,7 +41,7 @@ class DocumentTest extends \Flowpack\ElasticSearch\Tests\Functional\Domain\Abstr
      */
     public function idOfFreshNewDocumentIsPopulatedAfterStoring(array $data = null)
     {
-        $document = new \Flowpack\ElasticSearch\Domain\Model\Document(new TwitterType($this->testingIndex), $data);
+        $document = new Document(new TwitterType($this->testingIndex), $data);
         $this->assertNull($document->getId());
         $document->store();
         $this->assertRegExp('/\w+/', $document->getId());
@@ -52,7 +53,7 @@ class DocumentTest extends \Flowpack\ElasticSearch\Tests\Functional\Domain\Abstr
      */
     public function versionOfFreshNewDocumentIsCreatedAfterStoringAndIncreasedAfterSubsequentStoring(array $data = null)
     {
-        $document = new \Flowpack\ElasticSearch\Domain\Model\Document(new TwitterType($this->testingIndex), $data);
+        $document = new Document(new TwitterType($this->testingIndex), $data);
         $this->assertNull($document->getVersion());
         $document->store();
         $idAfterFirstStoring = $document->getId();
@@ -69,7 +70,7 @@ class DocumentTest extends \Flowpack\ElasticSearch\Tests\Functional\Domain\Abstr
     public function existingIdOfDocumentIsNotModifiedAfterStoring(array $data)
     {
         $id = '42-1010-42';
-        $document = new \Flowpack\ElasticSearch\Domain\Model\Document(new TwitterType($this->testingIndex), $data, $id);
+        $document = new Document(new TwitterType($this->testingIndex), $data, $id);
         $document->store();
         $this->assertSame($id, $document->getId());
     }

--- a/Tests/Functional/Fixtures/Tweet.php
+++ b/Tests/Functional/Fixtures/Tweet.php
@@ -18,7 +18,7 @@ use \Flowpack\ElasticSearch\Annotations as ElasticSearch;
  * An object for the "twitter" index, representing a "tweet" document.
  *
  * @Flow\Entity
- * @ElasticSearch\Indexable(indexName="flow3_elasticsearch_functionaltests_twitter", typeName="tweet")
+ * @ElasticSearch\Indexable(indexName="flow_elasticsearch_functionaltests_twitter", typeName="tweet")
  */
 class Tweet
 {

--- a/Tests/Functional/Indexer/Object/IndexInformerTest.php
+++ b/Tests/Functional/Indexer/Object/IndexInformerTest.php
@@ -11,12 +11,16 @@ namespace Flowpack\ElasticSearch\Tests\Functional\Indexer\Object;
  * source code.
  */
 
+use Flowpack\ElasticSearch\Annotations\Indexable as IndexableAnnotation;
+use Flowpack\ElasticSearch\Indexer\Object\IndexInformer;
+use Flowpack\ElasticSearch\Tests\Functional\Fixtures;
+
 /**
  */
 class IndexInformerTest extends \TYPO3\Flow\Tests\FunctionalTestCase
 {
     /**
-     * @var \Flowpack\ElasticSearch\Indexer\Object\IndexInformer
+     * @var IndexInformer
      */
     protected $informer;
 
@@ -25,7 +29,7 @@ class IndexInformerTest extends \TYPO3\Flow\Tests\FunctionalTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->informer = $this->objectManager->get('Flowpack\ElasticSearch\Indexer\Object\IndexInformer');
+        $this->informer = $this->objectManager->get(IndexInformer::class);
     }
 
     /**
@@ -33,8 +37,8 @@ class IndexInformerTest extends \TYPO3\Flow\Tests\FunctionalTestCase
      */
     public function classAnnotationTest()
     {
-        $actual = $this->informer->getClassAnnotation('Flowpack\ElasticSearch\Tests\Functional\Fixtures\JustFewPropertiesToIndex');
-        $this->assertInstanceOf('Flowpack\ElasticSearch\Annotations\Indexable', $actual);
+        $actual = $this->informer->getClassAnnotation(Fixtures\JustFewPropertiesToIndex::class);
+        $this->assertInstanceOf(IndexableAnnotation::class, $actual);
         $this->assertSame('dummyindex', $actual->indexName);
         $this->assertSame('sampletype', $actual->typeName);
     }
@@ -44,7 +48,7 @@ class IndexInformerTest extends \TYPO3\Flow\Tests\FunctionalTestCase
      */
     public function classWithOnlyOnePropertyAnnotatedHasOnlyThisPropertyToBeIndexed()
     {
-        $actual = $this->informer->getClassProperties('Flowpack\ElasticSearch\Tests\Functional\Fixtures\JustFewPropertiesToIndex');
+        $actual = $this->informer->getClassProperties(Fixtures\JustFewPropertiesToIndex::class);
         $this->assertCount(1, $actual);
     }
 
@@ -53,7 +57,7 @@ class IndexInformerTest extends \TYPO3\Flow\Tests\FunctionalTestCase
      */
     public function classWithNoPropertyAnnotatedHasAllPropertiesToBeIndexed()
     {
-        $actual = $this->informer->getClassProperties('Flowpack\ElasticSearch\Tests\Functional\Fixtures\Tweet');
+        $actual = $this->informer->getClassProperties(Fixtures\Tweet::class);
         $this->assertGreaterThan(1, $actual);
     }
 }

--- a/Tests/Functional/Indexer/Object/ObjectIndexerTest.php
+++ b/Tests/Functional/Indexer/Object/ObjectIndexerTest.php
@@ -89,7 +89,9 @@ class ObjectIndexerTest extends \TYPO3\Flow\Tests\FunctionalTestCase
             ->findType('tweet')
             ->findDocumentById($identifier);
 
-        $this->assertSame($initialVersion + 1, $changedDocument->getVersion());
+        // the version increments by two, since we index via AOP and via Doctrine lifecycle events
+        // see https://github.com/Flowpack/Flowpack.ElasticSearch/pull/36
+        $this->assertSame($initialVersion + 2, $changedDocument->getVersion());
         $this->assertSame($changedDocument->getField('message'), 'changed message.');
     }
 

--- a/Tests/Functional/Indexer/Object/ObjectIndexerTest.php
+++ b/Tests/Functional/Indexer/Object/ObjectIndexerTest.php
@@ -11,8 +11,11 @@ namespace Flowpack\ElasticSearch\Tests\Functional\Indexer\Object;
  * source code.
  */
 
+use Flowpack\ElasticSearch\Domain\Model\Document;
+use Flowpack\ElasticSearch\Indexer\Object\ObjectIndexer;
 use Flowpack\ElasticSearch\Tests\Functional\Fixtures\TweetRepository;
 use Flowpack\ElasticSearch\Tests\Functional\Fixtures\Tweet;
+use TYPO3\Flow\Utility\Algorithms;
 
 /**
  */
@@ -39,7 +42,7 @@ class ObjectIndexerTest extends \TYPO3\Flow\Tests\FunctionalTestCase
     {
         parent::setUp();
         $this->testEntityRepository = new TweetRepository();
-        $this->testClient = $this->objectManager->get('Flowpack\ElasticSearch\Indexer\Object\ObjectIndexer')->getClient();
+        $this->testClient = $this->objectManager->get(ObjectIndexer::class)->getClient();
     }
 
     /**
@@ -51,7 +54,7 @@ class ObjectIndexerTest extends \TYPO3\Flow\Tests\FunctionalTestCase
         $documentId = $this->persistenceManager->getIdentifierByObject($testEntity);
 
         $resultDocument = $this->testClient
-            ->findIndex('flow3_elasticsearch_functionaltests_twitter')
+            ->findIndex('flow_elasticsearch_functionaltests_twitter')
             ->findType('tweet')
             ->findDocumentById($documentId);
         $resultData = $resultDocument->getData();
@@ -69,7 +72,7 @@ class ObjectIndexerTest extends \TYPO3\Flow\Tests\FunctionalTestCase
         $identifier = $this->persistenceManager->getIdentifierByObject($testEntity);
 
         $initialVersion = $this->testClient
-            ->findIndex('flow3_elasticsearch_functionaltests_twitter')
+            ->findIndex('flow_elasticsearch_functionaltests_twitter')
             ->findType('tweet')
             ->findDocumentById($identifier)
             ->getVersion();
@@ -82,7 +85,7 @@ class ObjectIndexerTest extends \TYPO3\Flow\Tests\FunctionalTestCase
         $this->persistenceManager->clearState();
 
         $changedDocument = $this->testClient
-            ->findIndex('flow3_elasticsearch_functionaltests_twitter')
+            ->findIndex('flow_elasticsearch_functionaltests_twitter')
             ->findType('tweet')
             ->findDocumentById($identifier);
 
@@ -99,10 +102,10 @@ class ObjectIndexerTest extends \TYPO3\Flow\Tests\FunctionalTestCase
         $identifier = $this->persistenceManager->getIdentifierByObject($testEntity);
 
         $initialDocument = $this->testClient
-            ->findIndex('flow3_elasticsearch_functionaltests_twitter')
+            ->findIndex('flow_elasticsearch_functionaltests_twitter')
             ->findType('tweet')
             ->findDocumentById($identifier);
-        $this->assertInstanceOf('Flowpack\ElasticSearch\Domain\Model\Document', $initialDocument);
+        $this->assertInstanceOf(Document::class, $initialDocument);
 
         $persistedTestEntity = $this->testEntityRepository->findByIdentifier($identifier);
         $this->testEntityRepository->remove($persistedTestEntity);
@@ -110,7 +113,7 @@ class ObjectIndexerTest extends \TYPO3\Flow\Tests\FunctionalTestCase
         $this->persistenceManager->clearState();
 
         $foundDocument = $this->testClient
-            ->findIndex('flow3_elasticsearch_functionaltests_twitter')
+            ->findIndex('flow_elasticsearch_functionaltests_twitter')
             ->findType('tweet')
             ->findDocumentById($identifier);
         $this->assertNull($foundDocument);
@@ -122,8 +125,8 @@ class ObjectIndexerTest extends \TYPO3\Flow\Tests\FunctionalTestCase
     {
         $testEntity = new Tweet();
         $testEntity->setDate(new \DateTime());
-        $testEntity->setMessage('This is a test message ' . \TYPO3\Flow\Utility\Algorithms::generateRandomString(8));
-        $testEntity->setUsername('Zak McKracken' . \TYPO3\Flow\Utility\Algorithms::generateRandomString(8));
+        $testEntity->setMessage('This is a test message ' . Algorithms::generateRandomString(8));
+        $testEntity->setUsername('Zak McKracken' . Algorithms::generateRandomString(8));
 
         $this->testEntityRepository->add($testEntity);
         $this->persistenceManager->persistAll();

--- a/Tests/Functional/Mapping/MappingBuilderTest.php
+++ b/Tests/Functional/Mapping/MappingBuilderTest.php
@@ -11,12 +11,15 @@ namespace Flowpack\ElasticSearch\Tests\Functional\Mapping;
  * source code.
  */
 
+use Flowpack\ElasticSearch\Domain\Model\Mapping;
+use Flowpack\ElasticSearch\Mapping\EntityMappingBuilder;
+
 /**
  */
 class MappingBuilderTest extends \TYPO3\Flow\Tests\FunctionalTestCase
 {
     /**
-     * @var \Flowpack\ElasticSearch\Mapping\EntityMappingBuilder
+     * @var EntityMappingBuilder
      */
     protected $mappingBuilder;
 
@@ -25,7 +28,7 @@ class MappingBuilderTest extends \TYPO3\Flow\Tests\FunctionalTestCase
     public function setUp()
     {
         parent::setUp();
-        $this->mappingBuilder = $this->objectManager->get('Flowpack\ElasticSearch\Mapping\EntityMappingBuilder');
+        $this->mappingBuilder = $this->objectManager->get(EntityMappingBuilder::class);
     }
 
     /**
@@ -35,6 +38,6 @@ class MappingBuilderTest extends \TYPO3\Flow\Tests\FunctionalTestCase
     {
         $information = $this->mappingBuilder->buildMappingInformation();
         $this->assertGreaterThanOrEqual(2, count($information));
-        $this->assertInstanceOf('Flowpack\ElasticSearch\Domain\Model\Mapping', $information[0]);
+        $this->assertInstanceOf(Mapping::class, $information[0]);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,10 +2,10 @@
     "name": "flowpack/elasticsearch",
     "type": "typo3-flow-package",
     "license": "MIT",
-    "description": "This package provides wrapper functionality for the elasticsearch engine.",
+    "description": "This package provides wrapper functionality for the Elasticsearch engine.",
     "require": {
         "ext-curl": "*",
-        "typo3/flow": "*"
+        "typo3/flow": "~3.0"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "flowpack/elasticsearch",
     "type": "typo3-flow-package",
+    "license": "MIT",
     "description": "This package provides wrapper functionality for the elasticsearch engine.",
     "require": {
         "ext-curl": "*",


### PR DESCRIPTION
This does some code style cleanup, fixes type hints and adjusts the code in two places:

- indexing skips non-gettable properties now
- no longer use deprecated `getClassNameByObject`

The latter makes this package depend on Flow 3.0 or higher.

Also, the package now contains a LICENSE file (MIT license).
