### PR TITLE
TASK: Avoid double indexing of entities

### DIFF
--- a/Classes/Flowpack/ElasticSearch/Indexer/Aspect/IndexerAspect.php
+++ b/Classes/Flowpack/ElasticSearch/Indexer/Aspect/IndexerAspect.php
@@ -29,7 +29,7 @@ class IndexerAspect
     /**
      * @Flow\AfterReturning("setting(Flowpack.ElasticSearch.realtimeIndexing.enabled) && within(TYPO3\Flow\Persistence\PersistenceManagerInterface) && method(public .+->(add|update)())")
      * @param \TYPO3\Flow\Aop\JoinPointInterface $joinPoint
-     * @return string
+     * @return void
      */
     public function updateObjectToIndex(\TYPO3\Flow\Aop\JoinPointInterface $joinPoint)
     {
@@ -39,14 +39,24 @@ class IndexerAspect
     }
 
     /**
-     * @Flow\AfterReturning("setting(Flowpack.ElasticSearch.realtimeIndexing.enabled) && within(TYPO3\Flow\Persistence\PersistenceManagerInterface) && method(public .+->(remove)())")
+     * @Flow\AfterReturning("setting(Flowpack.ElasticSearch.realtimeIndexing.enabled) && within(TYPO3\Flow\Persistence\PersistenceManagerInterface) && method(public .+->remove())")
      * @param \TYPO3\Flow\Aop\JoinPointInterface $joinPoint
-     * @return string
+     * @return void
      */
     public function removeObjectFromIndex(\TYPO3\Flow\Aop\JoinPointInterface $joinPoint)
     {
         $arguments = $joinPoint->getMethodArguments();
         $object = reset($arguments);
         $this->objectIndexer->removeObject($object);
+    }
+
+    /**
+     * @Flow\AfterReturning("setting(Flowpack.ElasticSearch.realtimeIndexing.enabled) && within(TYPO3\Flow\Persistence\PersistenceManagerInterface) && method(public .+->persistAll())")
+     * @param \TYPO3\Flow\Aop\JoinPointInterface $joinPoint
+     * @return void
+     */
+    public function clearIndexingState(\TYPO3\Flow\Aop\JoinPointInterface $joinPoint)
+    {
+        $this->objectIndexer->clearState();
     }
 }

--- a/Classes/Flowpack/ElasticSearch/Indexer/Object/Signal/Doctrine/EmitterAdapter.php
+++ b/Classes/Flowpack/ElasticSearch/Indexer/Object/Signal/Doctrine/EmitterAdapter.php
@@ -12,6 +12,7 @@ namespace Flowpack\ElasticSearch\Indexer\Object\Signal\Doctrine;
  */
 
 use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Mapping as ORM;
 use TYPO3\Flow\Annotations as Flow;
 
@@ -51,5 +52,14 @@ class EmitterAdapter implements \Flowpack\ElasticSearch\Indexer\Object\Signal\Em
     public function postRemove(LifecycleEventArgs $eventArguments)
     {
         $this->signalEmitter->emitObjectRemoved($eventArguments->getEntity());
+    }
+
+    /**
+     * @param PostFlushEventArgs $eventArguments
+     * @return void
+     */
+    public function postFlush(PostFlushEventArgs $eventArguments)
+    {
+        $this->signalEmitter->emitAllObjectsPersisted();
     }
 }

--- a/Classes/Flowpack/ElasticSearch/Indexer/Object/Signal/SignalEmitter.php
+++ b/Classes/Flowpack/ElasticSearch/Indexer/Object/Signal/SignalEmitter.php
@@ -45,4 +45,12 @@ class SignalEmitter
     public function emitObjectRemoved($object)
     {
     }
+
+    /**
+     * @Flow\Signal
+     * @return void
+     */
+    public function emitAllObjectsPersisted()
+    {
+    }
 }

--- a/Classes/Flowpack/ElasticSearch/Package.php
+++ b/Classes/Flowpack/ElasticSearch/Package.php
@@ -56,6 +56,7 @@ class Package extends BasePackage
             $bootstrap->getSignalSlotDispatcher()->connect(SignalEmitter::class, 'objectUpdated', ObjectIndexer::class, 'indexObject');
             $bootstrap->getSignalSlotDispatcher()->connect(SignalEmitter::class, 'objectPersisted', ObjectIndexer::class, 'indexObject');
             $bootstrap->getSignalSlotDispatcher()->connect(SignalEmitter::class, 'objectRemoved', ObjectIndexer::class, 'removeObject');
+            $bootstrap->getSignalSlotDispatcher()->connect(SignalEmitter::class, 'allObjectsPersisted', ObjectIndexer::class, 'clearState');
         }
     }
 }

--- a/Tests/Functional/Indexer/Object/ObjectIndexerTest.php
+++ b/Tests/Functional/Indexer/Object/ObjectIndexerTest.php
@@ -89,9 +89,7 @@ class ObjectIndexerTest extends \TYPO3\Flow\Tests\FunctionalTestCase
             ->findType('tweet')
             ->findDocumentById($identifier);
 
-        // the version increments by two, since we index via AOP and via Doctrine lifecycle events
-        // see https://github.com/Flowpack/Flowpack.ElasticSearch/pull/36
-        $this->assertSame($initialVersion + 2, $changedDocument->getVersion());
+        $this->assertSame($initialVersion + 1, $changedDocument->getVersion());
         $this->assertSame($changedDocument->getField('message'), 'changed message.');
     }
 


### PR DESCRIPTION
We index via AOP and via Doctrine lifecycle events. This may lead to double
indexing.

There was code in place to avoid double indexing, but that was removed as some
point, see https://github.com/Flowpack/Flowpack.ElasticSearch/pull/36.

This change brings back a check for objects that were already handled, based
on the persistence identifier that is used anyway.