### PR TITLE
TASK: Mark as compatible with Flow 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "description": "This package provides wrapper functionality for the Elasticsearch engine.",
     "require": {
         "ext-curl": "*",
-        "typo3/flow": "~2.3"
+        "typo3/flow": "~2.3|~3.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
There is one deprecated method call being used, but it works fine.