### PR TITLE
TASK: Tweak indentation of examples in Indexer.rst

### DIFF
--- a/Documentation/Indexer.rst
+++ b/Documentation/Indexer.rst
@@ -13,52 +13,52 @@ single properties, only these will be indexed. However, you have to annotate the
 
 *Example: Class where every property will be indexed* ::
 
-	/**
-	 * @Flow\Entity
-	 * @ElasticSearch\Indexable("twitter", typeName="tweet")
-	 */
-	class Tweet {
+    /**
+     * @Flow\Entity
+     * @ElasticSearch\Indexable("twitter", typeName="tweet")
+     */
+    class Tweet {
 
-		/**
-		 * @var string
-		 */
-		protected $username;
+        /**
+         * @var string
+         */
+        protected $username;
 
-		/**
-		 * @var string
-		 */
-		protected $message;
+        /**
+         * @var string
+         */
+        protected $message;
 
-		/**
-		 * @var \DateTime
-		 */
-		protected $date;
-	}
+        /**
+         * @var \DateTime
+         */
+        protected $date;
+    }
 
 *Example: Class where only the ``message`` property will be indexed* ::
 
-	/**
-	 * @Flow\Entity
-	 * @ElasticSearch\Indexable("twitter", typeName="tweet")
-	 */
-	class Tweet {
+    /**
+     * @Flow\Entity
+     * @ElasticSearch\Indexable("twitter", typeName="tweet")
+     */
+    class Tweet {
 
-		/**
-		 * @var string
-		 */
-		protected $username;
+        /**
+         * @var string
+         */
+        protected $username;
 
-		/**
-		 * @var string
-		 * @ElasticSearch\Indexable
-		 */
-		protected $message;
+        /**
+         * @var string
+         * @ElasticSearch\Indexable
+         */
+        protected $message;
 
-		/**
-		 * @var \DateTime
-		 */
-		protected $date;
-	}
+        /**
+         * @var \DateTime
+         */
+        protected $date;
+    }
 
 Mapping annotations
 ===================
@@ -67,23 +67,22 @@ ElasticSearch allows the mapping configuration done via annotations. See the exa
 
 *Example: Annotations to set up mapping directives* ::
 
-	/**
-	 * @var string
-	 * @ElasticSearch\Mapping(boost=2.0, term_vector="with_offsets")
-	 */
-	protected $username;
+    /**
+     * @var string
+     * @ElasticSearch\Mapping(boost=2.0, term_vector="with_offsets")
+     */
+    protected $username;
 
-	/**
-	 * @var string
-	 */
-	protected $message;
+    /**
+     * @var string
+     */
+    protected $message;
 
-	/**
-	 * @var \DateTime
-	 * @ElasticSearch\Mapping(format="YYYY-MM-dd")
-	 */
-	protected $date;
-
+    /**
+     * @var \DateTime
+     * @ElasticSearch\Mapping(format="YYYY-MM-dd")
+     */
+    protected $date;
 
 Note that for mapping creation, the type will automatically be determined from the PHP type the property is of.
 
@@ -93,12 +92,12 @@ Value transformations
 For some properties it'll be necessary to conduct specific conversions in order to meet the requirements of
 ElasticSearch. Declare custom type converters via their appropriate annotation::
 
-	/**
-	 * @var \DateTime
-	 * @ElasticSearch\Mapping(format="YYYY-MM-dd")
-	 * @ElasticSearch\Transform("Date")
-	 */
-	protected $date;
+    /**
+     * @var \DateTime
+     * @ElasticSearch\Mapping(format="YYYY-MM-dd")
+     * @ElasticSearch\Transform("Date")
+     */
+    protected $date;
 
 This will call the (supplied with the package) Date transformer and hand the converted value over to the ElasticSearch
 engine.
@@ -108,37 +107,37 @@ Setting up the indexes
 
 As soon as you have proper configuration for your entities, you can create your index, with the CLI utility::
 
-	flow index:create --index-name twitter
+    flow index:create --index-name twitter
 
 If you need advanced settings you can define them in your ``Settings.yaml``::
 
-	Flowpack:
-	  ElasticSearch:
-	  	indexes:
-		  default:
-			'twitter':
-			  analysis:
-				filter:
-				  elision:
-					type: 'elision'
-					articles: [ 'l', 'm', 't', 'qu', 'n', 's', 'j', 'd' ]
-			  analyzer:
-				custom_french_analyzer:
-				  tokenizer: 'letter'
-				  filter: [ 'asciifolding', 'lowercase', 'french_stem', 'elision', 'stop' ]
-				tag_analyzer:
-				  tokenizer: 'keyword'
-				  filter: [ 'asciifolding', 'lowercase' ]
+    Flowpack:
+      ElasticSearch:
+        indexes:
+          default:
+            'twitter':
+              analysis:
+                filter:
+                  elision:
+                    type: 'elision'
+                    articles: [ 'l', 'm', 't', 'qu', 'n', 's', 'j', 'd' ]
+                analyzer:
+                  custom_french_analyzer:
+                    tokenizer: 'letter'
+                    filter: [ 'asciifolding', 'lowercase', 'french_stem', 'elision', 'stop' ]
+                  tag_analyzer:
+                    tokenizer: 'keyword'
+                    filter: [ 'asciifolding', 'lowercase' ]
 
 If you use multiple client configurations, please change the ``default`` key just below the ``indexes``.
 
 You can update the index configuration with the following CLI::
 
-	flow index:updateSettings --index-name twitter
+    flow index:updateSettings --index-name twitter
 
 Please check the ElasticSearch configuration to know witch settings are updatable. For any other settings changes, you
 need to delete your indexes::
 
-	flow index:delete --index-name twitter
+    flow index:delete --index-name twitter
 
 .. [#suppProperties] *supported properties* are all scalar types, unless value transformation is applied.


### PR DESCRIPTION
This replaces tabs with spaces and clears up the way analysis settings
need to be indented.