### PR TITLE
BUGFIX: Version 2.x of elasticsearch does neither need nor accept index_name in fields mapping

### DIFF
--- a/Classes/Mapping/EntityMappingBuilder.php
+++ b/Classes/Mapping/EntityMappingBuilder.php
@@ -58,7 +58,7 @@ class EntityMappingBuilder
 
     /**
      * @var int
-     * @Flow\InjectConfiguration(path="driver.version")
+     * @Flow\InjectConfiguration(path="version")
      */
     protected $driverVersion;
 

--- a/Classes/Mapping/EntityMappingBuilder.php
+++ b/Classes/Mapping/EntityMappingBuilder.php
@@ -57,6 +57,12 @@ class EntityMappingBuilder
     protected $indexInformer;
 
     /**
+     * @var int
+     * @Flow\InjectConfiguration(path="driver.version")
+     */
+    protected $driverVersion;
+
+    /**
      * Builds a Mapping collection from the annotation sources that are present
      *
      * @return MappingCollection<Mapping>
@@ -125,6 +131,11 @@ class EntityMappingBuilder
                         throw new ElasticSearchException('Duplicate index name in the same multi field is not allowed "' . $className . '::' . $propertyName . '".');
                     }
                     $multiFieldAnnotation->type = $mappingType;
+
+                    if ($this->driverVersion === '2.x') {
+                        $multiFieldAnnotation->index_name = null;
+                    }
+
                     $multiFields[$multiFieldIndexName] = $this->processMappingAnnotation($multiFieldAnnotation);
                 }
                 $mapping->setPropertyByPath([$propertyName, 'fields'], $multiFields);

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,5 +1,6 @@
 Flowpack:
   ElasticSearch:
+    version: 2.x
     clients:
       default:
         -

--- a/README.md
+++ b/README.md
@@ -1,18 +1,25 @@
 # Flow Framework ElasticSearch Integration
 
-*supporting Elasticsearch versions 1.2.x to 2.4.x**
-
 This project connects the Flow Framework to Elasticsearch; enabling two main functionalities:
 
 * Full-Text Indexing of Doctrine Entities
 * Index configuration based on Annotations
 
-Related package:
+## Elastic version support
 
-* [Flowpack.ElasticSearch.ContentRepositoryAdaptor](https://github.com/Flowpack/Flowpack.ElasticSearch.ContentRepositoryAdaptor): An adapter to support the Neos Content Repository 
+You can set your Elasticsearch version by editing ```Settings.yaml```
+(```Flowpack.ElasticSearch.version```) with the following value:
+
+* ```1.x``` to support Elastic 1.2 to 1.7
+* ```2.x``` to support Elastic 2.x
+
+
+## Related package:
+
+* [Flowpack.ElasticSearch.ContentRepositoryAdaptor](https://github.com/Flowpack/Flowpack.ElasticSearch.ContentRepositoryAdaptor): An adapter to support the Neos Content Repository
 indexing and searching
 
-More documentation:
+## More documentation:
 
 * [General Documentation](Documentation/Index.rst)
 * [How to index your own model ?](Documentation/Indexer.rst)


### PR DESCRIPTION
Using an annotation like this:

```
    /**
     * @var string
     * @ORM\Column(nullable=true)
     * @ElasticSearch\Indexable
     * @ElasticSearch\Mapping(fields={@ElasticSearch\Mapping(index_name="raw", type="string", analyzer="case_insensitive_sort")})
     */
    protected $title;
```

with version 2.x of elasticsearch throws the error:
```json
{
  "error": {
    "root_cause": [
      {
        "type": "mapper_parsing_exception",
        "reason": "Mapping definition for [fields] has unsupported parameters: [index_name: raw]"
      }
    ],
    "type": "mapper_parsing_exception ",
    "reason": "Mapping definition for [fields] has unsupported parameters: [index_name: raw]"},
    "status": 400
  }
```