### PR TITLE
TASK: Fix supported Elasticsearch versions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flow Framework ElasticSearch Integration
 
-*supporting Elasticsearch versions 1.2.x to 1.7.x*
+*supporting Elasticsearch versions 1.2.x to 2.4.x*
 
 This project connects the Flow Framework to Elasticsearch; enabling two main functionalities:
 
@@ -9,7 +9,7 @@ This project connects the Flow Framework to Elasticsearch; enabling two main fun
 
 Related package:
 
-* [Flowpack.ElasticSearch.ContentRepositoryAdaptor](https://github.com/Flowpack/Flowpack.ElasticSearch.ContentRepositoryAdaptor): An adapter to support the TYPO3CR (Content Repository) 
+* [Flowpack.ElasticSearch.ContentRepositoryAdaptor](https://github.com/Flowpack/Flowpack.ElasticSearch.ContentRepositoryAdaptor): An adapter to support the TYPO3CR (Content Repository)
 indexing and searching
 
 More documentation:


### PR DESCRIPTION
The package is actually working with Elasticseach 2.x, contrary to
what the README said.