### PR TITLE
FEATURE: Property fielddata in Annotations/Mapping

### DIFF
--- a/Classes/Annotations/Mapping.php
+++ b/Classes/Annotations/Mapping.php
@@ -99,6 +99,12 @@ final class Mapping
     public $fields;
 
     /**
+     * @var bool
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/5.4/fielddata.html
+     */
+    public $fielddata;
+
+    /**
      * Returns this class's properties as type/value array in order to directly use it for mapping information
      *
      * @return array


### PR DESCRIPTION
In order to enable fielddata in the mapping-annotations the class Flowpack\ElasticSearch\Annotations\Mapping should have a property 'fielddata' (boolean).