### PR TITLE
Set Content Type header to application/json

### DIFF
--- a/Classes/Transfer/RequestService.php
+++ b/Classes/Transfer/RequestService.php
@@ -90,7 +90,8 @@ class RequestService
             $requestUri->setUsername($uri->getUsername());
             $requestUri->setPassword($uri->getPassword());
         }
-
+        
+        $request->setHeader('Content-Type', 'application/json');
         $response = $this->browser->sendRequest($request);
 
         return new Response($response, $this->browser->getLastRequest());


### PR DESCRIPTION
In the current Elastic Search Version the Content Type detection for rest requests is deprecated. This sets the Content Header explicit to application/json