### PR TITLE
fix content type

### DIFF
--- a/Classes/Flowpack/ElasticSearch/Transfer/RequestService.php
+++ b/Classes/Flowpack/ElasticSearch/Transfer/RequestService.php
@@ -89,6 +89,7 @@ class RequestService
             $requestUri->setPassword($uri->getPassword());
         }
 
+        $request->setHeader('Content-Type', 'application/json');
         $response = $this->browser->sendRequest($request);
         return new Response($response, $this->browser->getLastRequest());
     }


### PR DESCRIPTION
In the current Elastic Search Version the Content Type detection for rest requests is deprecated. This sets the Content Header explicit to application/json