### PR TITLE
Allow passing arguments on index creation

### DIFF
--- a/Classes/Domain/Model/Index.php
+++ b/Classes/Domain/Model/Index.php
@@ -172,11 +172,12 @@ class Index
     }
 
     /**
+     * @param array $arguments
      * @return void
      */
-    public function create()
+    public function create(array $arguments = [])
     {
-        $this->request('PUT', null, [], json_encode($this->getSettings()));
+        $this->request('PUT', null, $arguments, json_encode($this->getSettings()));
     }
 
     /**


### PR DESCRIPTION
Allow passing arguments on index creation to set some mappings for example
See here for examples to give settings and mappings on index creation: https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html#mappings
