### PR TITLE
Added "properties" property to mapping annotation

### DIFF
--- a/Classes/Annotations/Mapping.php
+++ b/Classes/Annotations/Mapping.php
@@ -99,6 +99,12 @@ final class Mapping
     public $fields;
 
     /**
+	 * @var array
+     * @see https://www.elastic.co/guide/en/elasticsearch/reference/5.6/properties.html
+	 */
+	public $properties;
+    
+    /**
      * Returns this class's properties as type/value array in order to directly use it for mapping information
      *
      * @return array

--- a/Classes/Annotations/Mapping.php
+++ b/Classes/Annotations/Mapping.php
@@ -99,9 +99,9 @@ final class Mapping
     public $fields;
 
     /**
-	   * @var array
+     * @var array
      * @see https://www.elastic.co/guide/en/elasticsearch/reference/5.6/properties.html
-	   */
+     */
     public $properties;
 
     /**


### PR DESCRIPTION
This is a much needed property to be able to index a "toOne" relation as "object" and specify properties of that relation to be indexed.
This all works perfectly well with a Custom Transformer but it is currently not possible to configure the mapping right. This simple change would change that.

See:
https://www.elastic.co/guide/en/elasticsearch/reference/5.6/properties.html