### PR TITLE
BUGFIX: Adapted delete check for new version (since 6.x)

### DIFF
--- a/Classes/Domain/Model/AbstractType.php
+++ b/Classes/Domain/Model/AbstractType.php
@@ -108,7 +108,7 @@ abstract class AbstractType
         $response = $this->request('DELETE', '/' . $id);
         $treatedContent = $response->getTreatedContent();
 
-        return $response->getStatusCode() === 200 && $treatedContent['found'] === true;
+        return $response->getStatusCode() === 200 && $treatedContent['result'] === 'deleted';
     }
 
     /**


### PR DESCRIPTION
Newser versions of Elasticsearch do not return `found` in the DELETE-Action. Meanwhile the result is in `result`. 

Here are two examples:

**2.x**:

```
{
    "_shards" : {
        "total" : 10,
        "failed" : 0,
        "successful" : 10
    },
    "found" : true,
    "_index" : "twitter",
    "_type" : "tweet",
    "_id" : "1",
    "_version" : 2
}
```

**6.x**:
```
{
    "_shards" : {
        "total" : 2,
        "failed" : 0,
        "successful" : 2
    },
    "_index" : "twitter",
    "_type" : "tweet",
    "_id" : "1",
    "_version" : 2,
    "_primary_term": 1,
    "_seq_no": 5,
    "result": "deleted"
}
```