### PR TITLE
BUGFIX: ltrim request path when index name is not used

### DIFF
--- a/Classes/Domain/Model/Index.php
+++ b/Classes/Domain/Model/Index.php
@@ -169,7 +169,7 @@ class Index
         if ($prefixIndex === true) {
             $path = '/' . $this->name . $path;
         } else {
-            $path = '/' . $path;
+            $path = '/' . ltrim($path, '/');
         }
 
         return $this->client->request($method, $path, $arguments, $content);


### PR DESCRIPTION
For ES 5 it can be a problem to have double slash in the url, which is mentioned here: https://discuss.elastic.co/t/getting-500-error-in-es5-0-0/65146/2

I stumbled upon this problem, after fixing an issue in DocumentDriver for the ContentRepositoryAdapter:
```
Elasticsearch request failed. [POST http://elasticsearch:9201//_search/scroll]: Array ( [root_cause] => Array ( [0] => Array ( [type] => string_index_out_of_bounds_exception [reason] => String index out of range: 0 ) ) [type] => string_index_out_of_bounds_exception [reason] => String index out of range: 0 ) ; Response body: {"error":{"root_cause":[{"type":"string_index_out_of_bounds_exception","reason":"String index out of range: 0"}],"type":"string_index_out_of_bounds_exception","reason":"String index out of range: 0"},"status":500} Request data: {"scroll":"1m","scroll_id":"DnF1ZXJ5VGhlbkZldGNoBQAAAAAAABCiFkZ6Qk04NTY1UUNHMnozUXNRWnVvSncAAAAAAAAQoBZGekJNODU2NVFDRzJ6M1FzUVp1b0p3AAAAAAAAEKMWRnpCTTg1NjVRQ0cyejNRc1FadW9KdwAAAAAAABCkFkZ6Qk04NTY1UUNHMnozUXNRWnVvSncAAAAAAAAQoRZGekJNODU2NVFDRzJ6M1FzUVp1b0p3"}
```

This PR fixes the double slash using `ltrim()` in case the request is created with `$prefixIndex=false`.