### PR TITLE
FEATURE: Allow configuring a prefix for the index name via Settings

### DIFF
--- a/Classes/Domain/Model/Index.php
+++ b/Classes/Domain/Model/Index.php
@@ -122,6 +122,13 @@ class Index
     public function injectSettings(array $settings): void
     {
         $this->settings = $settings;
+        $indexSettings = $this->getSettings();
+        if (!isset($indexSettings['prefix']) || empty($indexSettings['prefix'])) {
+            return;
+        }
+        // This is obviously a side effect but can only be done after injecting settings 
+        // and it needs to be done as early as possible
+        $this->name = $settings['prefix'] . '-' . $this->name;
     }
 
     /**


### PR DESCRIPTION
With this feature any configured index can get a prefix in ElasticSearch, making it possible to
have several contexts indexed into different indexes in the same elastic instance.
At the same time index settings are kept centralised and used by the "base" index name.