### PR TITLE
TASK: Modify to work with Elasticsearch 7

### DIFF
--- a/Classes/Domain/Factory/DocumentFactory.php
+++ b/Classes/Domain/Factory/DocumentFactory.php
@@ -19,6 +19,7 @@ use Flowpack\ElasticSearch\Transfer\Response;
 use Neos\Error\Messages\Error;
 use Neos\Error\Messages\Result as ErrorResult;
 use Neos\Flow\Annotations as Flow;
+use Neos\Utility\Arrays;
 
 /**
  * Reconstitute a Document from the ElasticSearch index.
@@ -45,7 +46,7 @@ class DocumentFactory
             $error = new Error('The received index name "%s" does not match the expected one "%s".', 1340264838, [$content['_index'], $type->getIndex()->getName()]);
             $verificationResults->addError($error);
         }
-        if (isset($content['_type']) && $type->getName() !== $content['_type']) {
+        if ($type->getName() !== Arrays::getValueByPath($content, '_source.neos_type')) {
             $error = new Error('The received type name "%s" does not match the expected one "%s".', 1340265103, [$content['_type'], $type->getName()]);
             $verificationResults->addError($error);
         }

--- a/Classes/Domain/Model/AbstractType.php
+++ b/Classes/Domain/Model/AbstractType.php
@@ -17,6 +17,7 @@ use Flowpack\ElasticSearch\Domain\Exception\DocumentPropertiesMismatchException;
 use Flowpack\ElasticSearch\Domain\Factory\DocumentFactory;
 use Flowpack\ElasticSearch\Transfer\Response;
 use Neos\Flow\Annotations as Flow;
+use Neos\Utility\TypeHandling;
 
 /**
  * An abstract document type. Implement your own or use the GenericType provided with this package.
@@ -81,9 +82,9 @@ abstract class AbstractType
      * @throws \Flowpack\ElasticSearch\Exception
      * @throws \Neos\Flow\Http\Exception
      */
-    public function findDocumentById(string $id): Document
+    public function findDocumentById(string $id): ?Document
     {
-        $response = $this->request('GET', '/' . $id);
+        $response = $this->request('GET', '/_doc/' . $id);
         if ($response->getStatusCode() !== 200) {
             return null;
         }

--- a/Classes/Domain/Model/Document.php
+++ b/Classes/Domain/Model/Document.php
@@ -92,10 +92,10 @@ class Document
     {
         if ($this->id !== null) {
             $method = 'PUT';
-            $path = '/' . $this->id;
+            $path = '/_doc/' . $this->id;
         } else {
             $method = 'POST';
-            $path = '';
+            $path = '/_doc/';
         }
 
         $response = $this->request($method, $path, [], json_encode($this->getData()));

--- a/Classes/Indexer/Object/ObjectIndexer.php
+++ b/Classes/Indexer/Object/ObjectIndexer.php
@@ -17,6 +17,7 @@ use Flowpack\ElasticSearch\Annotations\Transform as TransformAnnotation;
 use Flowpack\ElasticSearch\Domain\Model\Client;
 use Flowpack\ElasticSearch\Domain\Model\Document;
 use Flowpack\ElasticSearch\Domain\Model\GenericType;
+use Flowpack\ElasticSearch\Domain\Model\Mapping;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Persistence\PersistenceManagerInterface;
 use Neos\Flow\Reflection\ReflectionService;
@@ -121,7 +122,6 @@ class ObjectIndexer
     protected function getIndexablePropertiesAndValuesFromObject($object)
     {
         $className = TypeHandling::getTypeForValue($object);
-        $data = [];
         foreach ($this->indexInformer->getClassProperties($className) as $propertyName) {
             if (ObjectAccess::isPropertyGettable($object, $propertyName) === false) {
                 continue;
@@ -172,6 +172,7 @@ class ObjectIndexer
         $document = $type->findDocumentById($id);
         if ($document !== null) {
             $objectData = $this->getIndexablePropertiesAndValuesFromObject($object);
+            $objectData[Mapping::NEOS_TYPE_FIELD] = $type->getName();
             if (strcmp(json_encode($objectData), json_encode($document->getData())) === 0) {
                 $actionType = null;
             } else {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Flow Framework ElasticSearch Integration
 
-_Supporting Elasticsearch versions 5.x, 6.x and 7.x_
+_Supporting Elasticsearch versions 6.x and 7.x_
 
 This project connects the Flow Framework to Elasticsearch; enabling two main functionalities:
 


### PR DESCRIPTION
I changed the code to support Elasticsearch version 7 for custom domain model indexing. 

It will then no longer work with elasticsearch 5 because the API changed from ES version 5 to 6 why I introduced these changes:

- `\Flowpack\ElasticSearch\Domain\Model\AbstractType::findDocumentById` will use the path "_doc" to find documents
- `\Flowpack\ElasticSearch\Domain\Model\Document::store` will use the path "_doc" store documents to the index
