### PR TITLE
TASK: Add http scheme default to settings

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -5,6 +5,7 @@ Flowpack:
         -
           host: localhost
           port: 9200
+          scheme: 'http'
           username: ''
           password: ''
     realtimeIndexing:


### PR DESCRIPTION
This makes the option more visible and follows our guidelines for
"settings documentation"