### PR TITLE
BUGFIX: Removed index_name in MultiField-Mapping

### DIFF
--- a/Classes/Mapping/EntityMappingBuilder.php
+++ b/Classes/Mapping/EntityMappingBuilder.php
@@ -131,7 +131,9 @@ class EntityMappingBuilder
                     if (isset($multiFields[$multiFieldIndexName])) {
                         throw new ElasticSearchException('Duplicate index name in the same multi field is not allowed "' . $className . '::' . $propertyName . '".');
                     }
-                    $multiFieldAnnotation->type = $mappingType;
+                    if (!$multiFieldAnnotation->type) {
+                        $multiFieldAnnotation->type = $mappingType;
+                    }
                     $multiFields[$multiFieldIndexName] = $this->processMappingAnnotation($multiFieldAnnotation);
                 }
                 $mapping->setPropertyByPath([$propertyName, 'fields'], $multiFields);
@@ -150,7 +152,9 @@ class EntityMappingBuilder
             if ($directiveValue === null) {
                 continue;
             }
-            $propertyMapping = Arrays::setValueByPath($propertyMapping, $mappingDirective, $directiveValue);
+            if ($mappingDirective != 'index_name') {
+                $propertyMapping = Arrays::setValueByPath($propertyMapping, $mappingDirective, $directiveValue);
+            }
         }
 
         return $propertyMapping;


### PR DESCRIPTION
### Problem
Using a mapping with one field `@ElasticSearch\Mapping(type="text", fields={@ElasticSearch\Mapping(index_name="raw", type="keyword")})` results in a wrong mapping configuration. 

### Example based on [documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/indices-put-mapping.html#add-multi-fields-existing-field-ex)

How it should look like:
```json
{
  "properties": {
    "city": {
      "type": "text",
      "fields": {
        "raw": {
          "type": "keyword"
        }
      }
    }
  }
}
```
How it does look like:
```json
{
  "properties": {
    "city": {
      "type": "text",
      "fields": {
        "raw": {
          "type": "keyword",
          "index_name": "raw"
        }
      }
    }
  }
}
```

### Solution
This PR contains a simple fix by just not setting the `index_name` property in a field configuration.

### Setup
```
"neos/flow": "7.3.1",
"flowpack/elasticsearch-contentrepositoryadaptor": "~8.0",
"flowpack/elasticsearch": "~5.0",
```