### PR TITLE
BUGFIX: Fix deprecation warning with PHP 8

### DIFF
--- a/Classes/Domain/Factory/DocumentFactory.php
+++ b/Classes/Domain/Factory/DocumentFactory.php
@@ -37,7 +37,7 @@ class DocumentFactory
      * @return Model\Document
      * @throws DocumentPropertiesMismatchException
      */
-    public function createFromResponse(Model\AbstractType $type, $id = null, Response $response)
+    public function createFromResponse(Model\AbstractType $type, $id, Response $response)
     {
         $content = $response->getTreatedContent();
 


### PR DESCRIPTION
This removes the warning

`PHP Deprecated:  Required parameter $response follows optional parameter $id in Application/Flowpack.ElasticSearch/Classes/Domain/Factory/DocumentFactory.php on line 40`