### PR TITLE
TASK: add settings to control transport ssl checks if necessary

### DIFF
--- a/Classes/Transfer/RequestService.php
+++ b/Classes/Transfer/RequestService.php
@@ -67,6 +67,8 @@ class RequestService
     {
         $requestEngine = new CurlEngine();
         $requestEngine->setOption(CURLOPT_TIMEOUT, $this->settings['transfer']['connectionTimeout']);
+        $requestEngine->setOption(CURLOPT_SSL_VERIFYPEER, $this->settings['transfer']['sslVerifyPeer']);
+        $requestEngine->setOption(CURLOPT_SSL_VERIFYHOST, $this->settings['transfer']['sslVerifyHost']);
         $this->browser->setRequestEngine($requestEngine);
     }
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -13,6 +13,8 @@ Flowpack:
       client: default
     transfer:
       connectionTimeout: 60
+      sslVerifyPeer: true
+      sslVerifyHost: true
 Neos:
   Flow:
     persistence:


### PR DESCRIPTION
Sometimes it's necessary to control SSL verification if you have a cluster running in a local infrastructure with self signed certificates  