### PR TITLE
BUGFIX: Setting injection doesn't cause errors

### DIFF
--- a/Classes/Domain/Model/Index.php
+++ b/Classes/Domain/Model/Index.php
@@ -122,13 +122,6 @@ class Index
     public function injectSettings(array $settings): void
     {
         $this->settings = $settings;
-        $indexSettings = $this->getSettings();
-        if (!isset($indexSettings['prefix']) || empty($indexSettings['prefix'])) {
-            return;
-        }
-        // This is obviously a side effect but can only be done after injecting settings 
-        // and it needs to be done as early as possible
-        $this->name = $settings['prefix'] . '-' . $this->name;
     }
 
     /**
@@ -173,11 +166,11 @@ class Index
     public function request(string $method, string $path = null, array $arguments = [], $content = null, bool $prefixIndex = true): Response
     {
         if ($this->client === null) {
-            throw new ElasticSearchException('The client of the index "' . $this->name . '" is not set, hence no requests can be done.', 1566313883);
+            throw new ElasticSearchException('The client of the index "' . $this->prefixName() . '" is not set, hence no requests can be done.', 1566313883);
         }
         $path = ltrim($path ? trim($path) : '', '/');
         if ($prefixIndex === true) {
-            $path = '/' . $this->name . '/' . $path;
+            $path = '/' . $this->prefixName() . '/' . $path;
         } else {
             $path = '/' . ltrim($path, '/');
         }
@@ -253,6 +246,11 @@ class Index
      */
     public function getName(): string
     {
+        return $this->prefixName();
+    }
+
+    public function getOriginalName(): string
+    {
         return $this->name;
     }
 
@@ -272,5 +270,20 @@ class Index
     public function setSettingsKey(string $settingsKey): void
     {
         $this->settingsKey = $settingsKey;
+    }
+
+    /**
+     * Prepends configured preset to the base index name
+     *
+     * @return string
+     */
+    private function prefixName(): string
+    {
+        $indexSettings = $this->getSettings();
+        if (!isset($indexSettings['prefix']) || empty($indexSettings['prefix'])) {
+            return $this->name;
+        }
+
+        return $indexSettings['prefix'] . '-' . $this->name;
     }
 }

--- a/Configuration/Testing/Settings.yaml
+++ b/Configuration/Testing/Settings.yaml
@@ -1,0 +1,22 @@
+Flowpack:
+  ElasticSearch:
+    clients:
+      FunctionalTests:
+        -
+          host: localhost
+          port: 9200
+          scheme: 'http'
+          username: ''
+          password: ''
+    realtimeIndexing:
+      # we also use this setting for the object indexer client bundle
+      client: FunctionalTests
+
+    indexes:
+      FunctionalTests: # Configuration bundle name
+        index_with_prefix: # The index prefix name, must be the same as in the Neos.ContentRepository.Search.elasticSearch.indexName setting
+          settings:
+            prefix: 'prefix'
+        index_without_prefix:
+          settings:
+            prefix: ~

--- a/Tests/Functional/Domain/AbstractTest.php
+++ b/Tests/Functional/Domain/AbstractTest.php
@@ -40,7 +40,7 @@ abstract class AbstractTest extends FunctionalTestCase
         parent::setUp();
 
         $this->clientFactory = $this->objectManager->get(ClientFactory::class);
-        $client = $this->clientFactory->create();
+        $client = $this->clientFactory->create("FunctionalTests");
         $this->testingIndex = $client->findIndex('flow_elasticsearch_functionaltests');
 
         if ($this->testingIndex->exists()) {

--- a/Tests/Functional/Domain/IndexTest.php
+++ b/Tests/Functional/Domain/IndexTest.php
@@ -1,0 +1,45 @@
+<?php
+namespace Flowpack\ElasticSearch\Tests\Functional\Domain;
+
+/*
+ * This file is part of the Flowpack.ElasticSearch package.
+ *
+ * (c) Contributors of the Flowpack Team - flowpack.org
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Flowpack\ElasticSearch\Domain\Model\Index;
+
+class IndexTest extends FunctionalTestCase
+{
+    /**
+     * @test
+     */
+    public function indexWithoutPrefix()
+    {
+        $this->clientFactory = $this->objectManager->get(ClientFactory::class);
+        $client = $this->clientFactory->create("FunctionalTests");
+        $testObject = new Index('index_without_prefix', $client);
+        
+        static::assertSame('index_without_prefix', $index->getOriginalName());
+        static::assertSame('index_without_prefix', $index->getName());
+        static::assert(['prefix' => null], $index->getSettings());
+    }
+
+    /**
+     * @test
+     */
+    public function indexWithPrefix()
+    {
+        $this->clientFactory = $this->objectManager->get(ClientFactory::class);
+        $client = $this->clientFactory->create("FunctionalTests");
+        $testObject = new Index('index_with_prefix', $client);
+        
+        static::assertSame('index_with_prefix', $index->getOriginalName());
+        static::assertSame('prefix_index_with_prefix', $index->getName());
+        static::assert(['prefix' => 'prefix'], $index->getSettings());
+    }
+}


### PR DESCRIPTION
Due to the order of operations with `injectSettings` and object injection it could cause errors to resolve the index settings early enough to override the name property.
This is now resolved later. Additionally via
`Index::getOriginalName()` one can now obtain the name without prefix, if necessary.