### PR TITLE
BUGFIX: Setting injection doesn't cause errors

### DIFF
--- a/Classes/Domain/Model/Index.php
+++ b/Classes/Domain/Model/Index.php
@@ -192,7 +192,7 @@ class Index
     public function create(): void
     {
         $indexConfiguration = $this->getConfiguration() ?? [];
-        $indexCreateObject = is_array($indexConfiguration) ? array_filter($indexConfiguration, static fn($key) => in_array($key, self::$allowedIndexCreateKeys, true), ARRAY_FILTER_USE_KEY) : [];
+        $indexCreateObject = array_filter($indexConfiguration, static fn($key) => in_array($key, self::$allowedIndexCreateKeys, true), ARRAY_FILTER_USE_KEY);
         $this->request('PUT', null, [], $this->encodeRequestBody($indexCreateObject));
     }
 
@@ -301,7 +301,7 @@ class Index
 
     private function encodeRequestBody(array $content): string
     {
-        if (empty($content)) {
+        if ($content === []) {
             return '';
         }
 

--- a/Classes/Domain/Model/Index.php
+++ b/Classes/Domain/Model/Index.php
@@ -191,9 +191,9 @@ class Index
      */
     public function create(): void
     {
-        $indexConfiguration = $this->getConfiguration();
-        $indexCreateObject = array_filter($indexConfiguration, static fn($key) => in_array($key, self::$allowedIndexCreateKeys, true), ARRAY_FILTER_USE_KEY);
-        $this->request('PUT', null, [], json_encode($indexCreateObject));
+        $indexConfiguration = $this->getConfiguration() ?? [];
+        $indexCreateObject = is_array($indexConfiguration) ? array_filter($indexConfiguration, static fn($key) => in_array($key, self::$allowedIndexCreateKeys, true), ARRAY_FILTER_USE_KEY) : [];
+        $this->request('PUT', null, [], $this->encodeRequestBody($indexCreateObject));
     }
 
     /**
@@ -227,7 +227,7 @@ class Index
             }
         }
         if ($updatableSettings !== []) {
-            $this->request('PUT', '/_settings', [], json_encode($updatableSettings));
+            $this->request('PUT', '/_settings', [], $this->encodeRequestBody($updatableSettings));
         }
     }
 
@@ -297,5 +297,14 @@ class Index
         }
 
         return $indexConfiguration['prefix'] . '-' . $this->name;
+    }
+
+    private function encodeRequestBody(array $content): string
+    {
+        if (empty($content)) {
+            return '';
+        }
+
+        return json_encode($content);
     }
 }

--- a/Classes/Service/DynamicIndexSettingService.php
+++ b/Classes/Service/DynamicIndexSettingService.php
@@ -20,6 +20,7 @@ use Neos\Utility\PositionalArraySorter;
 
 /**
  * Transform indices settings dynamically
+ * FIXME: This should be called DynamicIndexConfigurationService, the "settings" represent more than what elastic index "settings" are.
  *
  * @Flow\Scope("singleton")
  */

--- a/Configuration/Testing/Settings.yaml
+++ b/Configuration/Testing/Settings.yaml
@@ -1,0 +1,29 @@
+Flowpack:
+  ElasticSearch:
+    clients:
+      FunctionalTests:
+        -
+          host: localhost
+          port: 9200
+          scheme: 'http'
+          username: ''
+          password: ''
+    realtimeIndexing:
+      # we also use this setting for the object indexer client bundle
+      client: FunctionalTests
+
+    indexes:
+      FunctionalTests: # Configuration bundle name
+        index_with_prefix: # The index prefix name, must be the same as in the Neos.ContentRepository.Search.elasticSearch.indexName setting
+          prefix: 'prefix'
+          settings:
+            index:
+              number_of_replicas: 1
+              soft_deletes:
+                enabled: true
+        index_without_prefix:
+          settings:
+            index:
+              number_of_replicas: 2
+              soft_deletes:
+                enabled: true

--- a/Tests/Functional/Domain/AbstractTest.php
+++ b/Tests/Functional/Domain/AbstractTest.php
@@ -40,7 +40,7 @@ abstract class AbstractTest extends FunctionalTestCase
         parent::setUp();
 
         $this->clientFactory = $this->objectManager->get(ClientFactory::class);
-        $client = $this->clientFactory->create();
+        $client = $this->clientFactory->create("FunctionalTests");
         $this->testingIndex = $client->findIndex('flow_elasticsearch_functionaltests');
 
         if ($this->testingIndex->exists()) {

--- a/Tests/Functional/Domain/IndexTest.php
+++ b/Tests/Functional/Domain/IndexTest.php
@@ -1,0 +1,120 @@
+<?php
+namespace Flowpack\ElasticSearch\Tests\Functional\Domain;
+
+/*
+ * This file is part of the Flowpack.ElasticSearch package.
+ *
+ * (c) Contributors of the Flowpack Team - flowpack.org
+ *
+ * This package is Open Source Software. For the full copyright and license
+ * information, please view the LICENSE file which was distributed with this
+ * source code.
+ */
+
+use Flowpack\ElasticSearch\Domain\Model\Client;
+use Flowpack\ElasticSearch\Transfer\Response;
+use Neos\Flow\Tests\FunctionalTestCase;
+use Flowpack\ElasticSearch\Domain\Model\Index;
+
+class IndexTest extends FunctionalTestCase
+{
+    /**
+     * @test
+     */
+    public function indexWithoutPrefix()
+    {
+        $clientMock = $this->createMock(Client::class);
+        $clientMock->method('getBundle')
+            ->willReturn('FunctionalTests');
+
+        $clientMock->expects($this->exactly(2))->method('request')
+            ->withConsecutive(
+                [
+                    'PUT',
+                    '/index_without_prefix/',
+                    [],
+                    json_encode([
+                        'settings' => [
+                            'index' => [
+                                'number_of_replicas' => 2,
+                                'soft_deletes' => [
+                                    'enabled' => true
+                                ]
+                            ]
+                        ]
+                    ], JSON_THROW_ON_ERROR)
+                ],
+                // updateSettings should correctly filter soft_deletes as it's not in the allow list
+                [
+                    'PUT',
+                    '/index_without_prefix/_settings',
+                    [],
+                    json_encode([
+                        'settings' => [
+                            'index' => [
+                                'number_of_replicas' => 2
+                            ]
+                        ]
+                    ], JSON_THROW_ON_ERROR)
+                ]
+            )
+            ->willReturn($this->createStub(Response::class));
+
+        $testObject = new Index('index_without_prefix', $clientMock);
+        $testObject->create();
+        $testObject->updateSettings();
+
+        static::assertSame('index_without_prefix', $testObject->getOriginalName());
+        static::assertSame('index_without_prefix', $testObject->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function indexWithPrefix()
+    {
+        $clientMock = $this->createMock(Client::class);
+        $clientMock->method('getBundle')
+            ->willReturn('FunctionalTests');
+
+        $clientMock->expects($this->exactly(2))->method('request')
+            ->withConsecutive(
+                [
+                    'PUT',
+                    '/prefix-index_with_prefix/',
+                    [],
+                    json_encode([
+                        'settings' => [
+                            'index' => [
+                                'number_of_replicas' => 1,
+                                'soft_deletes' => [
+                                    'enabled' => true
+                                ]
+                            ]
+                        ]
+                    ], JSON_THROW_ON_ERROR)
+                ],
+                // updateSettings should correctly filter soft_deletes as it's not in the allow list
+                [
+                    'PUT',
+                    '/prefix-index_with_prefix/_settings',
+                    [],
+                    json_encode([
+                        'settings' => [
+                            'index' => [
+                                'number_of_replicas' => 1
+                            ]
+                        ]
+                    ], JSON_THROW_ON_ERROR)
+                ]
+            )
+            ->willReturn($this->createStub(Response::class));
+
+        $testObject = new Index('index_with_prefix', $clientMock);
+        $testObject->create();
+        $testObject->updateSettings();
+
+        static::assertSame('index_with_prefix', $testObject->getOriginalName());
+        static::assertSame('prefix-index_with_prefix', $testObject->getName());
+    }
+}

--- a/Tests/Functional/Domain/IndexTest.php
+++ b/Tests/Functional/Domain/IndexTest.php
@@ -50,10 +50,8 @@ class IndexTest extends FunctionalTestCase
                     '/index_without_prefix/_settings',
                     [],
                     json_encode([
-                        'settings' => [
-                            'index' => [
-                                'number_of_replicas' => 2
-                            ]
+                        'index' => [
+                            'number_of_replicas' => 2
                         ]
                     ], JSON_THROW_ON_ERROR)
                 ]
@@ -100,10 +98,8 @@ class IndexTest extends FunctionalTestCase
                     '/prefix-index_with_prefix/_settings',
                     [],
                     json_encode([
-                        'settings' => [
-                            'index' => [
-                                'number_of_replicas' => 1
-                            ]
+                        'index' => [
+                            'number_of_replicas' => 1
                         ]
                     ], JSON_THROW_ON_ERROR)
                 ]


### PR DESCRIPTION
Due to the order of operations with injectSettings and object injection it could cause errors to resolve the index settings early enough to override the name property.

This is now resolved later. Additionally via `Index::getOriginalName()` one can now obtain the name without prefix, if necessary.

Testing overhauled with custom bundle as defined in Readme.

Additionally fixed the filtering of settings on `update` which was not working correctly (anymore?)

Fixes: #103 