### PR TITLE
allow null values for username and password - libcurl problems

### DIFF
--- a/Classes/Domain/Model/Client/ClientConfiguration.php
+++ b/Classes/Domain/Model/Client/ClientConfiguration.php
@@ -38,12 +38,12 @@ class ClientConfiguration
     protected $scheme = 'http';
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $username = '';
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $password = '';
 
@@ -107,9 +107,9 @@ class ClientConfiguration
     /**
      * Returns username
      *
-     * @return string
+     * @return string|null
      */
-    public function getUsername(): string
+    public function getUsername(): ?string
     {
         return $this->username;
     }
@@ -117,10 +117,10 @@ class ClientConfiguration
     /**
      * Sets username
      *
-     * @param string $username
+     * @param string|null $username
      * @return void
      */
-    public function setUsername(string $username): void
+    public function setUsername(?string $username): void
     {
         $this->username = $username;
     }
@@ -128,9 +128,9 @@ class ClientConfiguration
     /**
      * Returns password
      *
-     * @return string
+     * @return string|null
      */
-    public function getPassword(): string
+    public function getPassword(): ?string
     {
         return $this->password;
     }
@@ -138,10 +138,10 @@ class ClientConfiguration
     /**
      * Sets password
      *
-     * @param string $password
+     * @param string|null $password
      * @return void
      */
-    public function setPassword(string $password): void
+    public function setPassword(?string $password): void
     {
         $this->password = $password;
     }


### PR DESCRIPTION
Currently no null values are allowed for username and password.

This leads to potentially undesired behavior when guzzle/psr7 is used as Uri builder.

See this line https://github.com/guzzle/psr7/blob/2.6/src/Uri.php#L438

Currently only strings are allowed which means any url without any auth information will be built like this:

```
https://:@DOMAIN.TLD/...
```

This is seemingly not an issue for older curl versions.

We had the case where we upgraded from libcurl 7.79.1 to 8.0.1 and our application stopped working. This is because newer curl versions respect empty Http Basic auth and still set the proper header values. In our case this prevented the communication to AWS OpenSearch, since no authentication was expected.

If like in our case no authentication should be used, valid yaml null values like ```null``` and ```~``` could be used to type safe set those to null.

Let me know if you need changes or more information.