### PR TITLE
TASK: Remove include_type_name default parameter

### DIFF
--- a/Classes/Domain/Model/Mapping.php
+++ b/Classes/Domain/Model/Mapping.php
@@ -100,7 +100,7 @@ class Mapping
     {
         $content = json_encode($this->asArray());
 
-        return $this->type->request('PUT', '/_mapping', ['include_type_name' => 'false'], $content);
+        return $this->type->request('PUT', '/_mapping', [], $content);
     }
 
     /**


### PR DESCRIPTION
The parameter was previously deprecated and removed in elasticsearch 8