### PR TITLE
TASK: remove Authorization header if username and password are null

### DIFF
--- a/Classes/Domain/Model/Client/ClientConfiguration.php
+++ b/Classes/Domain/Model/Client/ClientConfiguration.php
@@ -38,14 +38,14 @@ class ClientConfiguration
     protected $scheme = 'http';
 
     /**
-     * @var string
+     * @var string|null
      */
-    protected $username = '';
+    protected $username = null;
 
     /**
-     * @var string
+     * @var string|null
      */
-    protected $password = '';
+    protected $password = null;
 
     /**
      * @Flow\Inject
@@ -120,7 +120,7 @@ class ClientConfiguration
      * @param string $username
      * @return void
      */
-    public function setUsername(string $username): void
+    public function setUsername(?string $username): void
     {
         $this->username = $username;
     }
@@ -138,10 +138,10 @@ class ClientConfiguration
     /**
      * Sets password
      *
-     * @param string $password
+     * @param string|null $password
      * @return void
      */
-    public function setPassword(string $password): void
+    public function setPassword(?string $password): void
     {
         $this->password = $password;
     }
@@ -151,10 +151,15 @@ class ClientConfiguration
      */
     public function getUri(): UriInterface
     {
-        return $this->uriFactory->createUri()
+        $uriWithoutAuthorization = $this->uriFactory->createUri()
             ->withScheme($this->scheme)
             ->withHost($this->host)
-            ->withPort($this->port)
-            ->withUserInfo($this->username, $this->password);
+            ->withPort($this->port);
+
+        if ($this->username === null && $this->password === null) {
+            return $uriWithoutAuthorization;
+        }
+
+        return $uriWithoutAuthorization->withUserInfo($this->username, $this->password);
     }
 }


### PR DESCRIPTION
Fixes the issue https://github.com/Flowpack/Flowpack.ElasticSearch/issues/115 by allowing to set the `username` and `password` to null. If both values are null, the `Authorization` header is not applied to the ElasticSearch request.

https://github.com/Flowpack/Flowpack.ElasticSearch/issues/115 